### PR TITLE
When in Debug mode show more logs

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -128,6 +129,22 @@ func (c *Container) Lookup() *Container {
 	c.Container, c.Err = inspect(client, containers[0].ID)
 
 	return c
+}
+
+func (c *Container) Log(stdout io.Writer, stderr io.Writer, follow bool) error {
+	client, err := NewClient(c.dockerHost)
+	if err != nil {
+		return err
+	}
+
+	return client.Logs(dockerClient.LogsOptions{
+		Container:    c.Name,
+		Stdout:       true,
+		Stderr:       true,
+		Follow:       follow,
+		OutputStream: stdout,
+		ErrorStream:  stderr,
+	})
 }
 
 func inspect(client *dockerClient.Client, id string) (*dockerClient.Container, error) {

--- a/init/sysinit.go
+++ b/init/sysinit.go
@@ -132,6 +132,10 @@ func runContainersFrom(startFrom string, cfg *config.Config, containerConfigs []
 				log.Errorf("Failed to run %v: %v", containerConfig.Id, container.Err)
 			}
 
+			if cfg.Debug {
+				container.Log(os.Stdout, os.Stderr, false)
+			}
+
 			if containerConfig.ReloadConfig {
 				log.Info("Reloading configuration")
 				err := cfg.Reload()
@@ -158,11 +162,6 @@ func tailConsole(cfg *config.Config) error {
 		return nil
 	}
 
-	client, err := docker.NewSystemClient()
-	if err != nil {
-		return err
-	}
-
 	for _, container := range cfg.SystemContainers {
 		if container.Id != config.CONSOLE_CONTAINER {
 			continue
@@ -174,14 +173,7 @@ func tailConsole(cfg *config.Config) error {
 		}
 
 		log.Infof("Tailing console : %s", c.Name)
-		return client.Logs(dockerClient.LogsOptions{
-			Container:    c.Name,
-			Stdout:       true,
-			Stderr:       true,
-			Follow:       true,
-			OutputStream: os.Stdout,
-			ErrorStream:  os.Stderr,
-		})
+		return c.Log(os.Stdout, os.Stderr, true)
 	}
 
 	log.Error("Console not found")


### PR DESCRIPTION
When in debug=true dump the log output of the container to
stdout/stderror so that it can be read from console on boot. This
is particularly helpful when troubleshooting installation problems
over a serial console. 