### PR TITLE
isolate and mark platform dependent code

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -3,17 +3,17 @@ package config
 import "github.com/rancherio/rancher-compose/librcompose/project"
 
 const (
-	CONSOLE_CONTAINER     = "console"
-	DOCKER_BIN            = "/usr/bin/docker"
-	DOCKER_SYSTEM_HOME    = "/var/lib/system-docker"
-	DOCKER_SYSTEM_HOST    = "unix:///var/run/system-docker.sock"
-	DOCKER_HOST           = "unix:///var/run/docker.sock"
-	IMAGES_PATH           = "/"
-	IMAGES_PATTERN        = "images*.tar"
-	SYS_INIT              = "/sbin/init-sys"
-	USER_INIT             = "/sbin/init-user"
-	MODULES_ARCHIVE       = "/modules.tar"
-	DEBUG                 = false
+	CONSOLE_CONTAINER  = "console"
+	DOCKER_BIN         = "/usr/bin/docker"
+	DOCKER_SYSTEM_HOME = "/var/lib/system-docker"
+	DOCKER_SYSTEM_HOST = "unix:///var/run/system-docker.sock"
+	DOCKER_HOST        = "unix:///var/run/docker.sock"
+	IMAGES_PATH        = "/"
+	IMAGES_PATTERN     = "images*.tar"
+	SYS_INIT           = "/sbin/init-sys"
+	USER_INIT          = "/sbin/init-user"
+	MODULES_ARCHIVE    = "/modules.tar"
+	DEBUG              = false
 
 	LABEL         = "label"
 	HASH          = "io.rancher.os.hash"

--- a/docker/container_test.go
+++ b/docker/container_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dockerClient "github.com/fsouza/go-dockerclient"
+	"os"
 )
+
+func testDockerHost(t *testing.T) {
+	assert := require.New(t)
+	assert.Equal(os.Getenv("DOCKER_HOST"), config.DOCKER_HOST)
+}
 
 func TestHash(t *testing.T) {
 	assert := require.New(t)
@@ -134,7 +140,7 @@ func TestIdFromName(t *testing.T) {
 	assert.Equal("foo", cfg.Id)
 }
 
-func TestMigrateVolumes(t *testing.T) {
+func testMigrateVolumes(t *testing.T) {
 	assert := require.New(t)
 
 	c := NewContainer(config.DOCKER_HOST, &config.ContainerConfig{
@@ -163,7 +169,7 @@ func TestMigrateVolumes(t *testing.T) {
 	c2.Delete()
 }
 
-func TestRollback(t *testing.T) {
+func testRollback(t *testing.T) {
 	assert := require.New(t)
 
 	c := NewContainer(config.DOCKER_HOST, &config.ContainerConfig{
@@ -197,7 +203,7 @@ func TestRollback(t *testing.T) {
 	c2.Delete()
 }
 
-func TestStart(t *testing.T) {
+func testStart(t *testing.T) {
 	assert := require.New(t)
 
 	c := NewContainer(config.DOCKER_HOST, &config.ContainerConfig{
@@ -213,7 +219,7 @@ func TestStart(t *testing.T) {
 	c.Delete()
 }
 
-func TestLookup(t *testing.T) {
+func testLookup(t *testing.T) {
 	assert := require.New(t)
 
 	cfg := &config.ContainerConfig{
@@ -242,7 +248,7 @@ func TestLookup(t *testing.T) {
 	c2.Delete()
 }
 
-func TestDelete(t *testing.T) {
+func testDelete(t *testing.T) {
 	assert := require.New(t)
 
 	c := NewContainer(config.DOCKER_HOST, &config.ContainerConfig{
@@ -268,7 +274,7 @@ func TestDelete(t *testing.T) {
 	assert.NoError(c.Err, "")
 }
 
-func TestDockerClientNames(t *testing.T) {
+func testDockerClientNames(t *testing.T) {
 	assert := require.New(t)
 	client, err := dockerClient.NewClient(config.DOCKER_HOST)
 

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package init
 
 import (
@@ -77,7 +79,7 @@ outer:
 			"autoformat": {
 				Net:        "none",
 				Privileged: true,
-				Image:      "rancher/os-autoformat:"+config.VERSION,
+				Image:      "rancher/os-autoformat:" + config.VERSION,
 				Command:    project.NewCommand(format),
 				Labels: project.NewSliceorMap(map[string]string{
 					config.DETACH: "false",

--- a/init/init.go
+++ b/init/init.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package init
 
 import (

--- a/util/cutil.go
+++ b/util/cutil.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package util
 
 /*

--- a/util/util.go
+++ b/util/util.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"syscall"
 
 	"gopkg.in/yaml.v2"
 
@@ -42,37 +41,6 @@ func GetOSType() string {
 	}
 	return "busybox"
 
-}
-
-func mountProc() error {
-	if _, err := os.Stat("/proc/self/mountinfo"); os.IsNotExist(err) {
-		if _, err := os.Stat("/proc"); os.IsNotExist(err) {
-			if err = os.Mkdir("/proc", 0755); err != nil {
-				return err
-			}
-		}
-
-		if err := syscall.Mount("none", "/proc", "proc", 0, ""); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func Mount(device, directory, fsType, options string) error {
-	if err := mountProc(); err != nil {
-		return nil
-	}
-
-	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		err = os.MkdirAll(directory, 0755)
-		if err != nil {
-			return err
-		}
-	}
-
-	return mount.Mount(device, directory, fsType, options)
 }
 
 func Remount(directory, options string) error {

--- a/util/util_linux.go
+++ b/util/util_linux.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package util
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/docker/docker/pkg/mount"
+)
+
+func mountProc() error {
+	if _, err := os.Stat("/proc/self/mountinfo"); os.IsNotExist(err) {
+		if _, err := os.Stat("/proc"); os.IsNotExist(err) {
+			if err = os.Mkdir("/proc", 0755); err != nil {
+				return err
+			}
+		}
+
+		if err := syscall.Mount("none", "/proc", "proc", 0, ""); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func Mount(device, directory, fsType, options string) error {
+	if err := mountProc(); err != nil {
+		return nil
+	}
+
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		err = os.MkdirAll(directory, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	return mount.Mount(device, directory, fsType, options)
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestLoadResourceSimple(t *testing.T) {
+	assert := require.New(t)
+
+	expected := `services:
+- debian-console
+- ubuntu-console
+`
+	expected = strings.TrimSpace(expected)
+
+	b, e := LoadResource("https://raw.githubusercontent.com/rancherio/os-services/v0.3.4/index.yml", true, []string{})
+
+	assert.Nil(e)
+	assert.Equal(expected, strings.TrimSpace(string(b)))
+}


### PR DESCRIPTION
isolate and mark platform dependent code

now unit tests compile on OS X and (some of them) work