### PR TITLE
move auto-formatter decision logic to os-autoformat container

### DIFF
--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -82,6 +82,9 @@ func imagesFromConfig(cfg *config.Config) []string {
 	for _, service := range cfg.BootstrapContainers {
 		imagesMap[service.Image] = 1
 	}
+	for _, service := range cfg.Autoformat {
+		imagesMap[service.Image] = 1
+	}
 	for _, service := range cfg.SystemContainers {
 		imagesMap[service.Image] = 1
 	}

--- a/config/types.go
+++ b/config/types.go
@@ -52,7 +52,8 @@ type Repositories map[string]Repository
 type Config struct {
 	Environment         map[string]string                 `yaml:"environment,omitempty"`
 	Services            map[string]*project.ServiceConfig `yaml:"services,omitempty"`
-	BootstrapContainers map[string]*project.ServiceConfig `yaml:"bootstrap_containers,omitempty"`
+	BootstrapContainers map[string]*project.ServiceConfig `yaml:"bootstrap,omitempty"`
+	Autoformat          map[string]*project.ServiceConfig `yaml:"autoformat,omitempty"`
 	BootstrapDocker     DockerConfig                      `yaml:"bootstrap_docker,omitempty"`
 	CloudInit           CloudInit                         `yaml:"cloud_init,omitempty"`
 	Console             ConsoleConfig                     `yaml:"console,omitempty"`
@@ -124,6 +125,7 @@ type StateConfig struct {
 	Dev        string   `yaml:"dev,omitempty"`
 	Required   bool     `yaml:"required,omitempty"`
 	Autoformat []string `yaml:"autoformat,omitempty"`
+	FormatZero bool     `yaml:"formatzero,omitempty"`
 }
 
 type CloudInit struct {

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -68,10 +68,6 @@ func stopDocker(c chan interface{}) error {
 }
 
 func bootstrap(cfg *config.Config) error {
-	if util.ResolveDevice(cfg.State.Dev) != "" {
-		return nil
-	}
-
 	log.Info("Launching Bootstrap Docker")
 	c, err := startDocker(cfg)
 	if err != nil {

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -21,11 +21,13 @@ func autoformat(cfg *config.Config) error {
 	AUTOFORMAT := "AUTOFORMAT=" + strings.Join(cfg.State.Autoformat, " ")
 	FORMATZERO := "FORMATZERO=" + fmt.Sprint(cfg.State.FormatZero)
 	cfg.Autoformat["autoformat"].Environment = project.NewMaporEqualSlice([]string{AUTOFORMAT, FORMATZERO})
+	log.Info("Running Autoformat services")
 	err := docker.RunServices("autoformat", cfg, cfg.Autoformat)
 	return err
 }
 
 func runBootstrapContainers(cfg *config.Config) error {
+	log.Info("Running Bootstrap services")
 	return docker.RunServices("bootstrap", cfg, cfg.BootstrapContainers)
 }
 
@@ -70,7 +72,7 @@ func bootstrap(cfg *config.Config) error {
 		return nil
 	}
 
-	log.Info("Starting bootstrap")
+	log.Info("Launching Bootstrap Docker")
 	c, err := startDocker(cfg)
 	if err != nil {
 		return err

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -1,102 +1,28 @@
-// +build linux
-
 package init
 
 import (
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancherio/os/config"
 	"github.com/rancherio/os/docker"
 	"github.com/rancherio/os/util"
 	"github.com/rancherio/rancher-compose/librcompose/project"
+	"strings"
 )
-
-const boot2dockerMagic = "boot2docker, please format-me"
 
 func autoformat(cfg *config.Config) error {
 	if len(cfg.State.Autoformat) == 0 || util.ResolveDevice(cfg.State.Dev) != "" {
 		return nil
 	}
-
-	var format string
-
-outer:
-	for _, dev := range cfg.State.Autoformat {
-		log.Infof("Checking %s to auto-format", dev)
-		if _, err := os.Stat(dev); os.IsNotExist(err) {
-			continue
-		}
-
-		f, err := os.Open(dev)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		buffer := make([]byte, 1048576, 1048576)
-		c, err := f.Read(buffer)
-		if err != nil {
-			return err
-		}
-
-		if c != 1048576 {
-			log.Infof("%s not right size", dev)
-			continue
-		}
-
-		boot2docker := false
-
-		if strings.HasPrefix(string(buffer[:len(boot2dockerMagic)]), boot2dockerMagic) {
-			boot2docker = true
-		}
-
-		if boot2docker == false {
-			for _, b := range buffer {
-				if b != 0 {
-					log.Infof("%s not empty", dev)
-					continue outer
-				}
-			}
-		}
-
-		format = dev
-		break
-	}
-
-	if format != "" {
-		log.Infof("Auto formatting : %s", format)
-
-		// copy
-		udev := *cfg.BootstrapContainers["udev"]
-		udev.Links = project.NewMaporColonSlice(append(udev.Links.Slice(), "autoformat"))
-		udev.LogDriver = "json-file"
-
-		err := docker.RunServices("autoformat", cfg, map[string]*project.ServiceConfig{
-			"autoformat": {
-				Net:        "none",
-				Privileged: true,
-				Image:      "rancher/os-autoformat:" + config.VERSION,
-				Command:    project.NewCommand(format),
-				Labels: project.NewSliceorMap(map[string]string{
-					config.DETACH: "false",
-					config.SCOPE:  config.SYSTEM,
-				}),
-				LogDriver: "json-file",
-				Environment: project.NewMaporEqualSlice([]string{
-					"MAGIC=" + boot2dockerMagic,
-				}),
-			},
-			"udev": &udev,
-		})
-
-		return err
-	}
-
-	return nil
+	AUTOFORMAT := "AUTOFORMAT=" + strings.Join(cfg.State.Autoformat, " ")
+	FORMATZERO := "FORMATZERO=" + fmt.Sprint(cfg.State.FormatZero)
+	cfg.Autoformat["autoformat"].Environment = project.NewMaporEqualSlice([]string{AUTOFORMAT, FORMATZERO})
+	err := docker.RunServices("autoformat", cfg, cfg.Autoformat)
+	return err
 }
 
 func runBootstrapContainers(cfg *config.Config) error {

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -66,6 +66,10 @@ func stopDocker(c chan interface{}) error {
 }
 
 func bootstrap(cfg *config.Config) error {
+	if util.ResolveDevice(cfg.State.Dev) != "" {
+		return nil
+	}
+
 	log.Info("Starting bootstrap")
 	c, err := startDocker(cfg)
 	if err != nil {

--- a/os-config.yml
+++ b/os-config.yml
@@ -1,4 +1,4 @@
-bootstrap_containers:
+bootstrap:
   udev:
     image: rancher/os-udev:v0.4.0-dev
     command: []
@@ -10,6 +10,42 @@ bootstrap_containers:
       io.rancher.os.detach: false
       io.rancher.os.scope: system
     links: []
+    log_driver: json-file
+    net: host
+    uts: host
+    privileged: true
+    volumes:
+    - /dev:/host/dev
+    - /lib/modules:/lib/modules
+    - /lib/firmware:/lib/firmware
+autoformat:
+  autoformat:
+    image: rancher/os-autoformat:v0.4.0-dev
+    command: []
+    dns: []
+    dns_search: []
+    env_file: []
+    environment: []
+    labels:
+      io.rancher.os.detach: false
+      io.rancher.os.scope: system
+    links: []
+    log_driver: json-file
+    net: none
+    privileged: true
+    volumes: []
+  udev:
+    image: rancher/os-udev:v0.4.0-dev
+    command: []
+    dns: []
+    dns_search: []
+    env_file: []
+    environment: []
+    labels:
+      io.rancher.os.detach: false
+      io.rancher.os.scope: system
+    links:
+    - autoformat
     log_driver: json-file
     net: host
     uts: host

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -40,7 +40,7 @@ chmod +x ${INITRD_DIR}/docker                                               #ini
 
 ln -sf bin/rancheros ./ros
 
-for i in $(./ros c images -i os-config.yml) rancher/os-autoformat:${VERSION}; do
+for i in $(./ros c images -i os-config.yml); do
     docker pull ${i}
 done
-docker save $(./ros c images -i os-config.yml) rancher/os-autoformat:${VERSION} > ${INITRD_DIR}/images.tar   #initrd2-images: /images.tar
+docker save $(./ros c images -i os-config.yml) > ${INITRD_DIR}/images.tar   #initrd2-images: /images.tar

--- a/scripts/package
+++ b/scripts/package
@@ -30,7 +30,7 @@ default rancheros
 label rancheros
     kernel /boot/vmlinuz
     initrd /boot/initrd
-    append quiet rancher.password=rancher
+    append quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
 EOF
 
 cd ${CD}
@@ -43,24 +43,6 @@ xorriso \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
     -isohybrid-mbr /usr/lib/syslinux/isohdpfx.bin \
     -o ${DIST}/artifacts/rancheros.iso $(pwd)
-
-cat > ${CD}/boot/isolinux/isolinux.cfg << EOF
-default rancheros
-label rancheros
-    kernel /boot/vmlinuz
-    initrd /boot/initrd
-    append quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
-EOF
-
-cd ${CD}
-xorriso \
-    -publisher "Rancher Labs, Inc." \
-    -as mkisofs \
-    -l -J -R -V "RancherOS" \
-    -no-emul-boot -boot-load-size 4 -boot-info-table \
-    -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
-    -isohybrid-mbr /usr/lib/syslinux/isohdpfx.bin \
-    -o ${DIST}/artifacts/machine-rancheros.iso $(pwd)
 
 
 if [ -e ${DIST}/artficats/iso-checksums.txt ]; then

--- a/scripts/run
+++ b/scripts/run
@@ -86,7 +86,7 @@ fi
 
 UNAME=$(uname)
 
-KERNEL_ARGS="rancher.password=rancher console=ttyS0 ${QEMU_APPEND}"
+KERNEL_ARGS="quiet rancher.password=rancher console=ttyS0 ${QEMU_APPEND}"
 
 if [ "$UNAME" == "Darwin" ] && [ -x $(which xhyve) ]; then
 


### PR DESCRIPTION
move auto-formatter decision logic to os-autoformat container

and get rid of:
- machine-rancheros.iso,
- special case in build-images,
- some bootstrap.go code