### PR TITLE
persistent state disk on xhyve

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -103,14 +103,14 @@ if [ "$UNAME" == "Darwin" ] && [ -x $(which xhyve) ]; then
     mkisofs -R -V config-2 -o "${CLOUD_CONFIG_ISO}" "$(pwd)/cloud-init"
 
     echo PWD=`pwd`
-    exec sudo xhyve -H -P \
+    exec sudo xhyve -A -H -P -u \
         -m 4G \
         -s 0:0,hostbridge -s 31,lpc \
         -l com1,stdio \
         -s 2:0,virtio-net \
         -s 3,ahci-cd,${CLOUD_CONFIG_ISO} \
         -U a01fb25c-3a19-4759-a47a-2e353e51807d \
-        -f kexec,${KERNEL},${INITRD_TEST},"earlyprintk=serial acpi=off elevator=noop ${KERNEL_ARGS}"
+        -f kexec,${KERNEL},${INITRD_TEST},"earlyprintk=serial elevator=noop ${KERNEL_ARGS}"
 
 elif [ "$UNAME" == "Linux" ] && [ -x $(which qemu-system-x86_64) ]; then
     exec qemu-system-x86_64 -serial stdio \

--- a/scripts/run
+++ b/scripts/run
@@ -74,7 +74,9 @@ find . | cpio -H newc -o > ${INITRD_TEST}
 
 if [ ! -e ${HD} ]; then
     mkdir -p $(dirname ${HD})
-    gzip -dc ${HD_GZ} > ${HD}
+    if [ "$UNAME" == "Darwin" ]; then qemu-img create -f raw -o size=10G ${HD}
+    elif [ "$UNAME" == "Linux" ]; then gzip -dc ${HD_GZ} > ${HD};
+    fi
 fi
 
 mkdir -p $(dirname $USER_DATA)
@@ -92,7 +94,7 @@ else
     done
 fi
 
-KERNEL_ARGS="quiet rancher.password=rancher console=ttyS0 ${QEMU_APPEND}"
+KERNEL_ARGS="rancher.password=rancher console=ttyS0 ${QEMU_APPEND}"
 
 if [ "$UNAME" == "Darwin" ] && [ -x $(which xhyve) ]; then
 
@@ -109,8 +111,9 @@ if [ "$UNAME" == "Darwin" ] && [ -x $(which xhyve) ]; then
         -l com1,stdio \
         -s 2:0,virtio-net \
         -s 3,ahci-cd,${CLOUD_CONFIG_ISO} \
+        -s 4,virtio-blk,${HD} \
         -U a01fb25c-3a19-4759-a47a-2e353e51807d \
-        -f kexec,${KERNEL},${INITRD_TEST},"earlyprintk=serial elevator=noop ${KERNEL_ARGS}"
+        -f kexec,${KERNEL},${INITRD_TEST},"earlyprintk=serial elevator=noop rancher.state.formatzero=true rancher.state.autoformat=[/dev/sda,/dev/vda] ${KERNEL_ARGS}"
 
 elif [ "$UNAME" == "Linux" ] && [ -x $(which qemu-system-x86_64) ]; then
     exec qemu-system-x86_64 -serial stdio \

--- a/scripts/run
+++ b/scripts/run
@@ -16,11 +16,11 @@ HD_GZ=${ARTIFACTS}/empty-hd.img.gz
 INITRD_TMP=${BUILD}/$(sha1sum ${INITRD} | awk '{print $1}')
 INITRD_CURRENT=${BUILD}/initrd-current
 INITRD_TEST=${BUILD}/initrd.test
+UNAME=$(uname)
 USER_DATA=cloud-init/openstack/latest/user_data
 
 # PREREQ: brew install coreutils
 path() {
-    local UNAME=$(uname)
     if [ "$UNAME" == "Darwin" ]; then greadlink -f "$1"
     elif [ "$UNAME" == "Linux" ]; then readlink -f "$1";
     fi
@@ -91,8 +91,6 @@ else
         fi
     done
 fi
-
-UNAME=$(uname)
 
 KERNEL_ARGS="quiet rancher.password=rancher console=ttyS0 ${QEMU_APPEND}"
 


### PR DESCRIPTION
Completes xhyve support for running RancherOS development build on OS X 
with `./scripts/run`. Empty persistent disk image is created with `qemu-img`, then
formatted using RancherOS's autoformat feature. 

Fixes #379