### PR TITLE
make cloud-config the configuration mechanism for RancherOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .DS_Store
 .git
 .idea
+bin
+gopath
 tmp
 state
 build

--- a/cmd/control/env.go
+++ b/cmd/control/env.go
@@ -20,8 +20,8 @@ func envAction(c *cli.Context) {
 	args := c.Args()
 	osEnv := os.Environ()
 
-	envMap := make(map[string]string, len(cfg.Environment)+len(osEnv))
-	for k, v := range cfg.Environment {
+	envMap := make(map[string]string, len(cfg.Rancher.Environment)+len(osEnv))
+	for k, v := range cfg.Rancher.Environment {
 		envMap[k] = v
 	}
 	for k, v := range util.KVPairs2Map(osEnv) {

--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -249,5 +249,5 @@ func getUpgradeUrl() (string, error) {
 		return "", err
 	}
 
-	return cfg.Upgrade.Url, nil
+	return cfg.Rancher.Upgrade.Url, nil
 }

--- a/cmd/control/service.go
+++ b/cmd/control/service.go
@@ -2,7 +2,7 @@ package control
 
 import (
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -44,16 +44,16 @@ func disable(c *cli.Context) {
 	}
 
 	for _, service := range c.Args() {
-		if _, ok := cfg.ServicesInclude[service]; !ok {
+		if _, ok := cfg.Rancher.ServicesInclude[service]; !ok {
 			continue
 		}
 
-		cfg.ServicesInclude[service] = false
+		cfg.Rancher.ServicesInclude[service] = false
 		changed = true
 	}
 
 	if changed {
-		if err = cfg.Set("services_include", cfg.ServicesInclude); err != nil {
+		if err = cfg.Set("rancher.services_include", cfg.Rancher.ServicesInclude); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -67,15 +67,15 @@ func del(c *cli.Context) {
 	}
 
 	for _, service := range c.Args() {
-		if _, ok := cfg.ServicesInclude[service]; !ok {
+		if _, ok := cfg.Rancher.ServicesInclude[service]; !ok {
 			continue
 		}
-		delete(cfg.ServicesInclude, service)
+		delete(cfg.Rancher.ServicesInclude, service)
 		changed = true
 	}
 
 	if changed {
-		if err = cfg.Set("services_include", cfg.ServicesInclude); err != nil {
+		if err = cfg.Set("rancher.services_include", cfg.Rancher.ServicesInclude); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -89,20 +89,20 @@ func enable(c *cli.Context) {
 	}
 
 	for _, service := range c.Args() {
-		if val, ok := cfg.ServicesInclude[service]; !ok || !val {
+		if val, ok := cfg.Rancher.ServicesInclude[service]; !ok || !val {
 			if strings.HasPrefix(service, "/") && !strings.HasPrefix(service, "/var/lib/rancher/conf") {
 				log.Fatalf("ERROR: Service should be in path /var/lib/rancher/conf")
 			}
 			if _, err := docker.LoadServiceResource(service, true, cfg); err != nil {
 				log.Fatalf("could not load service %s", service)
 			}
-			cfg.ServicesInclude[service] = true
+			cfg.Rancher.ServicesInclude[service] = true
 			changed = true
 		}
 	}
 
 	if changed {
-		if err = cfg.Set("services_include", cfg.ServicesInclude); err != nil {
+		if err := cfg.Set("rancher.services_include", cfg.Rancher.ServicesInclude); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -115,11 +115,11 @@ func list(c *cli.Context) {
 	}
 
 	clone := make(map[string]bool)
-	for service, enabled := range cfg.ServicesInclude {
+	for service, enabled := range cfg.Rancher.ServicesInclude {
 		clone[service] = enabled
 	}
 
-	services, err := util.GetServices(cfg.Repositories.ToArray())
+	services, err := util.GetServices(cfg.Rancher.Repositories.ToArray())
 	if err != nil {
 		log.Fatalf("Failed to get services: %v", err)
 	}

--- a/cmd/control/tlsconf.go
+++ b/cmd/control/tlsconf.go
@@ -44,12 +44,12 @@ func tlsConfCommands() []cli.Command {
 	}
 }
 
-func writeCerts(generateServer bool, hostname []string, cfg *config.Config, certPath, keyPath, caCertPath, caKeyPath string) error {
+func writeCerts(generateServer bool, hostname []string, cfg *config.CloudConfig, certPath, keyPath, caCertPath, caKeyPath string) error {
 	if !generateServer {
 		return machineUtil.GenerateCert([]string{""}, certPath, keyPath, caCertPath, caKeyPath, NAME, BITS)
 	}
 
-	if cfg.UserDocker.ServerKey == "" || cfg.UserDocker.ServerCert == "" {
+	if cfg.Rancher.UserDocker.ServerKey == "" || cfg.Rancher.UserDocker.ServerCert == "" {
 		err := machineUtil.GenerateCert(hostname, certPath, keyPath, caCertPath, caKeyPath, NAME, BITS)
 		if err != nil {
 			return err
@@ -65,26 +65,28 @@ func writeCerts(generateServer bool, hostname []string, cfg *config.Config, cert
 			return err
 		}
 
-		return cfg.SetConfig(&config.Config{
-			UserDocker: config.DockerConfig{
-				CAKey:      cfg.UserDocker.CAKey,
-				CACert:     cfg.UserDocker.CACert,
-				ServerCert: string(cert),
-				ServerKey:  string(key),
+		return cfg.SetConfig(&config.CloudConfig{
+			Rancher: config.RancherConfig{
+				UserDocker: config.DockerConfig{
+					CAKey:      cfg.Rancher.UserDocker.CAKey,
+					CACert:     cfg.Rancher.UserDocker.CACert,
+					ServerCert: string(cert),
+					ServerKey:  string(key),
+				},
 			},
 		})
 	}
 
-	if err := ioutil.WriteFile(certPath, []byte(cfg.UserDocker.ServerCert), 0400); err != nil {
+	if err := ioutil.WriteFile(certPath, []byte(cfg.Rancher.UserDocker.ServerCert), 0400); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(keyPath, []byte(cfg.UserDocker.ServerKey), 0400)
+	return ioutil.WriteFile(keyPath, []byte(cfg.Rancher.UserDocker.ServerKey), 0400)
 
 }
 
-func writeCaCerts(cfg *config.Config, caCertPath, caKeyPath string) error {
-	if cfg.UserDocker.CACert == "" {
+func writeCaCerts(cfg *config.CloudConfig, caCertPath, caKeyPath string) error {
+	if cfg.Rancher.UserDocker.CACert == "" {
 		if err := machineUtil.GenerateCACertificate(caCertPath, caKeyPath, NAME, BITS); err != nil {
 			return err
 		}
@@ -99,10 +101,12 @@ func writeCaCerts(cfg *config.Config, caCertPath, caKeyPath string) error {
 			return err
 		}
 
-		err = cfg.SetConfig(&config.Config{
-			UserDocker: config.DockerConfig{
-				CAKey:  string(caKey),
-				CACert: string(caCert),
+		err = cfg.SetConfig(&config.CloudConfig{
+			Rancher: config.RancherConfig{
+				UserDocker: config.DockerConfig{
+					CAKey:  string(caKey),
+					CACert: string(caCert),
+				},
 			},
 		})
 		if err != nil {
@@ -112,11 +116,11 @@ func writeCaCerts(cfg *config.Config, caCertPath, caKeyPath string) error {
 		return nil
 	}
 
-	if err := ioutil.WriteFile(caCertPath, []byte(cfg.UserDocker.CACert), 0400); err != nil {
+	if err := ioutil.WriteFile(caCertPath, []byte(cfg.Rancher.UserDocker.CACert), 0400); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(caKeyPath, []byte(cfg.UserDocker.CAKey), 0400)
+	return ioutil.WriteFile(caKeyPath, []byte(cfg.Rancher.UserDocker.CAKey), 0400)
 }
 
 func tlsConfCreate(c *cli.Context) {

--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -20,14 +20,14 @@ import (
 func Main() {
 	args := os.Args
 	if len(args) > 1 {
-		fmt.Println("call " + args[0] + " to load network config from rancher.yml config file")
+		fmt.Println("call " + args[0] + " to load network config from cloud-config.yml")
 		return
 	}
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-	ApplyNetworkConfigs(&cfg.Network)
+	ApplyNetworkConfigs(&cfg.Rancher.Network)
 }
 
 func createInterfaces(netCfg *config.NetworkConfig) error {

--- a/cmd/respawn/respawn.go
+++ b/cmd/respawn/respawn.go
@@ -68,7 +68,7 @@ func run(c *cli.Context) {
 	var wg sync.WaitGroup
 
 	for _, line := range strings.Split(string(input), "\n") {
-		if strings.TrimSpace(line) == "" {
+		if strings.TrimSpace(line) == "" || strings.Index(strings.TrimSpace(line), "#") == 0 {
 			continue
 		}
 		wg.Add(1)

--- a/config/default.go
+++ b/config/default.go
@@ -1,13 +1,14 @@
 package config
 
-func NewConfig() *Config {
+func NewConfig() *CloudConfig {
 	return ReadConfig(OsConfigFile)
 }
 
-func ReadConfig(file string) *Config {
+func ReadConfig(file string) *CloudConfig {
 	if data, err := readConfig(nil, file); err == nil {
-		c := &Config{}
+		c := &CloudConfig{}
 		c.merge(data)
+		c.amendNils()
 		return c
 	} else {
 		return nil

--- a/config/init.go
+++ b/config/init.go
@@ -6,9 +6,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-type InitFunc func(*Config) error
+type InitFunc func(*CloudConfig) error
 
-func RunInitFuncs(cfg *Config, initFuncs []InitFunc) error {
+func RunInitFuncs(cfg *CloudConfig, initFuncs []InitFunc) error {
 	for i, initFunc := range initFuncs {
 		log.Debugf("[%d/%d] Starting", i+1, len(initFuncs))
 		if err := initFunc(cfg); err != nil {

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/rancherio/rancher-compose/librcompose/project"
+import (
+	"github.com/coreos/coreos-cloudinit/config"
+	"github.com/rancherio/rancher-compose/librcompose/project"
+)
 
 const (
 	CONSOLE_CONTAINER  = "console"
@@ -24,14 +27,17 @@ const (
 	RELOAD_CONFIG = "io.rancher.os.reloadconfig"
 	SCOPE         = "io.rancher.os.scope"
 	SYSTEM        = "system"
+
+	OsConfigFile          = "/os-config.yml"
+	CloudConfigFile       = "/var/lib/rancher/conf/cloud-config.yml"
+	CloudConfigScriptFile = "/var/lib/rancher/conf/cloud-config-script"
+	MetaDataFile          = "/var/lib/rancher/conf/metadata"
+	LocalConfigFile       = "/var/lib/rancher/conf/cloud-config-local.yml"
+	PrivateConfigFile     = "/var/lib/rancher/conf/cloud-config-private.yml"
 )
 
 var (
-	VERSION           string
-	OsConfigFile      = "/os-config.yml"
-	CloudConfigFile   = "/var/lib/rancher/conf/cloud-config-rancher.yml"
-	ConfigFile        = "/var/lib/rancher/conf/rancher.yml"
-	PrivateConfigFile = "/var/lib/rancher/conf/rancher-private.yml"
+	VERSION string
 )
 
 type ContainerConfig struct {
@@ -49,7 +55,16 @@ type Repository struct {
 
 type Repositories map[string]Repository
 
-type Config struct {
+type CloudConfig struct {
+	SSHAuthorizedKeys []string      `yaml:"ssh_authorized_keys"`
+	WriteFiles        []config.File `yaml:"write_files"`
+	Hostname          string        `yaml:"hostname"`
+	Users             []config.User `yaml:"users"`
+
+	Rancher RancherConfig `yaml:"rancher,omitempty"`
+}
+
+type RancherConfig struct {
 	Environment         map[string]string                 `yaml:"environment,omitempty"`
 	Services            map[string]*project.ServiceConfig `yaml:"services,omitempty"`
 	BootstrapContainers map[string]*project.ServiceConfig `yaml:"bootstrap,omitempty"`
@@ -65,7 +80,6 @@ type Config struct {
 	Repositories        Repositories                      `yaml:"repositories,omitempty"`
 	Ssh                 SshConfig                         `yaml:"ssh,omitempty"`
 	State               StateConfig                       `yaml:"state,omitempty"`
-	SystemContainers    map[string]*project.ServiceConfig `yaml:"system_containers,omitempty"`
 	SystemDocker        DockerConfig                      `yaml:"system_docker,omitempty"`
 	Upgrade             UpgradeConfig                     `yaml:"upgrade,omitempty"`
 	UserContainers      []ContainerConfig                 `yaml:"user_containers,omitempty"`

--- a/docker/factory.go
+++ b/docker/factory.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ContainerFactory struct {
-	cfg *config.Config
+	cfg *config.CloudConfig
 }
 
 type containerBasedService struct {
@@ -18,10 +18,10 @@ type containerBasedService struct {
 	project       *project.Project
 	container     *Container
 	serviceConfig *project.ServiceConfig
-	cfg           *config.Config
+	cfg           *config.CloudConfig
 }
 
-func NewContainerFactory(cfg *config.Config) *ContainerFactory {
+func NewContainerFactory(cfg *config.CloudConfig) *ContainerFactory {
 	return &ContainerFactory{
 		cfg: cfg,
 	}
@@ -34,7 +34,7 @@ func (c *containerBasedService) Up() error {
 	fakeCreate := false
 	create := containerCfg.CreateOnly
 
-	if util.Contains(c.cfg.Disable, c.name) {
+	if util.Contains(c.cfg.Rancher.Disable, c.name) {
 		fakeCreate = true
 	}
 

--- a/os-config.yml
+++ b/os-config.yml
@@ -1,419 +1,310 @@
-bootstrap:
-  udev:
-    image: rancher/os-udev:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: host
-    uts: host
-    privileged: true
-    volumes:
-    - /dev:/host/dev
-    - /lib/modules:/lib/modules
-    - /lib/firmware:/lib/firmware
-autoformat:
+rancher:
+  bootstrap:
+    udev:
+      image: rancher/os-udev:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: host
+      uts: host
+      privileged: true
+      volumes:
+      - /dev:/host/dev
+      - /lib/modules:/lib/modules
+      - /lib/firmware:/lib/firmware
   autoformat:
-    image: rancher/os-autoformat:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    volumes: []
-  udev:
-    image: rancher/os-udev:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links:
-    - autoformat
-    log_driver: json-file
-    net: host
-    uts: host
-    privileged: true
-    volumes:
-    - /dev:/host/dev
-    - /lib/modules:/lib/modules
-    - /lib/firmware:/lib/firmware
-bootstrap_docker:
-  args: [docker, -d, -s, overlay, -b, none, --restart=false, -g, /var/lib/system-docker,
-    -G, root, -H, 'unix:///var/run/system-docker.sock']
-cloud_init:
-  datasources:
-  - configdrive:/media/config-2
-services_include:
-  ubuntu-console: false
-network:
-  dns:
-    nameservers: [8.8.8.8, 8.8.4.4]
-  interfaces:
-    eth*:
-      dhcp: true
-    lo:
-      address: 127.0.0.1/8
-repositories:
-  core:
-    url: https://raw.githubusercontent.com/rancherio/os-services/v0.4.0
-state:
-  fstype: auto
-  dev: LABEL=RANCHER_STATE
-system_containers:
-  acpid:
-    image: rancher/os-acpid:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.scope: system
-    links: []
-    net: host
-    uts: host
-    privileged: true
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  all-volumes:
-    image: rancher/os-state:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.createonly: true
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    read_only: true
-    volumes_from:
-    - docker-volumes
-    - command-volumes
-    - user-volumes
-    - system-volumes
-  cloud-init:
-    image: rancher/os-cloudinit:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.reloadconfig: true
-      io.rancher.os.scope: system
-    links:
-    - preload-user-images
-    - cloud-init-pre
-    - network
-    net: host
-    uts: host
-    privileged: true
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  cloud-init-pre:
-    image: rancher/os-cloudinit:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment:
-    - CLOUD_INIT_NETWORK=false
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.reloadconfig: true
-      io.rancher.os.scope: system
-    links:
-    - preload-system-images
-    net: host
-    uts: host
-    privileged: true
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  command-volumes:
-    image: rancher/os-state:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.createonly: true
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    read_only: true
-    volumes:
-    - /init:/sbin/halt:ro
-    - /init:/sbin/poweroff:ro
-    - /init:/sbin/reboot:ro
-    - /init:/sbin/shutdown:ro
-    - /init:/sbin/netconf:ro
-    - /init:/usr/bin/cloud-init:ro
-    - /init:/usr/bin/rancherctl:ro
-    - /init:/usr/bin/ros:ro
-    - /init:/usr/bin/respawn:ro
-    - /init:/usr/bin/system-docker:ro
-    - /init:/usr/sbin/wait-for-docker:ro
-    - /lib/modules:/lib/modules
-    - /usr/bin/docker:/usr/bin/docker:ro
-  console:
-    image: rancher/os-console:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.remove: true
-      io.rancher.os.scope: system
-    links:
-    - cloud-init
-    net: host
-    uts: host
-    pid: host
-    ipc: host
-    privileged: true
-    restart: always
-    volumes_from:
-    - all-volumes
-  docker:
-    image: rancher/os-docker:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.scope: system
-    links:
-    - network
-    net: host
-    uts: host
-    pid: host
-    ipc: host
-    privileged: true
-    restart: always
-    volumes_from:
-    - all-volumes
-  docker-volumes:
-    image: rancher/os-state:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.createonly: true
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    read_only: true
-    volumes:
-    - /var/lib/rancher/conf:/var/lib/rancher/conf
-    - /var/lib/docker:/var/lib/docker
-    - /var/lib/system-docker:/var/lib/system-docker
-  dockerwait:
-    image: rancher/os-dockerwait:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links:
-    - docker
-    net: host
-    uts: host
-    volumes_from:
-    - all-volumes
+    autoformat:
+      image: rancher/os-autoformat:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+    udev:
+      image: rancher/os-udev:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      links:
+      - autoformat
+      log_driver: json-file
+      net: host
+      uts: host
+      privileged: true
+      volumes:
+      - /dev:/host/dev
+      - /lib/modules:/lib/modules
+      - /lib/firmware:/lib/firmware
+  bootstrap_docker:
+    args: [docker, -d, -s, overlay, -b, none, --restart=false, -g, /var/lib/system-docker,
+      -G, root, -H, 'unix:///var/run/system-docker.sock']
+  cloud_init:
+    datasources:
+    - configdrive:/media/config-2
+  services_include: {}
   network:
-    image: rancher/os-network:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links:
-    - cloud-init-pre
-    net: host
-    uts: host
-    privileged: true
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  ntp:
-    image: rancher/os-ntp:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.scope: system
-    links:
-    - cloud-init
-    - network
-    net: host
-    uts: host
-    privileged: true
-    restart: always
-  preload-system-images:
-    image: rancher/os-preload:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links: []
-    privileged: true
-    volumes:
-    - /var/run/system-docker.sock:/var/run/docker.sock
-    - /var/lib/system-docker/preload:/mnt/preload
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  preload-user-images:
-    image: rancher/os-preload:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.detach: false
-      io.rancher.os.scope: system
-    links:
-    - dockerwait
-    privileged: true
-    volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
-    - /var/lib/docker/preload:/mnt/preload
-    volumes_from:
-    - command-volumes
-    - system-volumes
-  syslog:
-    image: rancher/os-syslog:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: host
-    uts: host
-    privileged: true
-    restart: always
-    volumes_from:
-    - system-volumes
-  system-volumes:
-    image: rancher/os-state:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.createonly: true
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    read_only: true
-    volumes:
-    - /dev:/host/dev
-    - /os-config.yml:/os-config.yml
-    - /var/lib/rancher:/var/lib/rancher
-    - /var/lib/rancher/conf:/var/lib/rancher/conf
-    - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher
-    - /lib/modules:/lib/modules
-    - /lib/firmware:/lib/firmware
-    - /var/run:/var/run
-    - /var/log:/var/log
-  udev:
-    image: rancher/os-udev:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment:
-    - DAEMON=true
-    labels:
-      io.rancher.os.detach: true
-      io.rancher.os.scope: system
-    links: []
-    net: host
-    uts: host
-    privileged: true
-    restart: always
-    volumes_from:
-    - system-volumes
-  user-volumes:
-    image: rancher/os-state:v0.4.0-dev
-    command: []
-    dns: []
-    dns_search: []
-    env_file: []
-    environment: []
-    labels:
-      io.rancher.os.createonly: true
-      io.rancher.os.scope: system
-    links: []
-    log_driver: json-file
-    net: none
-    privileged: true
-    read_only: true
-    volumes:
-    - /home:/home
-    - /opt:/opt
-system_docker:
-  args: [docker, -d, --log-driver, syslog, -s, overlay, -b, docker-sys, --fixed-cidr,
-    172.18.42.1/16, --restart=false, -g, /var/lib/system-docker, -G, root,
-    -H, 'unix:///var/run/system-docker.sock', --userland-proxy=false]
-upgrade:
-  url: https://releases.rancher.com/os/versions.yml
-  image: rancher/os
-user_docker:
-  tls_args: [--tlsverify, --tlscacert=ca.pem, --tlscert=server-cert.pem, --tlskey=server-key.pem,
-    '-H=0.0.0.0:2376']
-  args: [docker, -d, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock', --userland-proxy=false]
+    dns:
+      nameservers: [8.8.8.8, 8.8.4.4]
+    interfaces:
+      eth*:
+        dhcp: true
+      lo:
+        address: 127.0.0.1/8
+  repositories:
+    core:
+      url: https://raw.githubusercontent.com/rancherio/os-services/v0.4.0
+  state:
+    fstype: auto
+    dev: LABEL=RANCHER_STATE
+  services:
+    acpid:
+      image: rancher/os-acpid:v0.4.0-dev
+      labels:
+        io.rancher.os.scope: system
+      net: host
+      uts: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    all-volumes:
+      image: rancher/os-state:v0.4.0-dev
+      labels:
+        io.rancher.os.createonly: true
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+      read_only: true
+      volumes_from:
+      - docker-volumes
+      - command-volumes
+      - user-volumes
+      - system-volumes
+    cloud-init:
+      image: rancher/os-cloudinit:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.reloadconfig: true
+        io.rancher.os.scope: system
+      links:
+      - cloud-init-pre
+      - network
+      net: host
+      uts: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    cloud-init-pre:
+      image: rancher/os-cloudinit:v0.4.0-dev
+      environment:
+      - CLOUD_INIT_NETWORK=false
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.reloadconfig: true
+        io.rancher.os.scope: system
+      links:
+      - preload-system-images
+      net: host
+      uts: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    command-volumes:
+      image: rancher/os-state:v0.4.0-dev
+      labels:
+        io.rancher.os.createonly: true
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+      read_only: true
+      volumes:
+      - /init:/sbin/halt:ro
+      - /init:/sbin/poweroff:ro
+      - /init:/sbin/reboot:ro
+      - /init:/sbin/shutdown:ro
+      - /init:/sbin/netconf:ro
+      - /init:/usr/bin/cloud-init:ro
+      - /init:/usr/bin/rancherctl:ro
+      - /init:/usr/bin/ros:ro
+      - /init:/usr/bin/respawn:ro
+      - /init:/usr/bin/system-docker:ro
+      - /init:/usr/sbin/wait-for-docker:ro
+      - /lib/modules:/lib/modules
+      - /usr/bin/docker:/usr/bin/docker:ro
+    console:
+      image: rancher/os-console:v0.4.0-dev
+      labels:
+        io.rancher.os.remove: true
+        io.rancher.os.scope: system
+      links:
+      - cloud-init
+      - dockerwait  # because console runs `loud-init -execute`, which may need docker
+      net: host
+      uts: host
+      pid: host
+      ipc: host
+      privileged: true
+      restart: always
+      volumes_from:
+      - all-volumes
+    docker:
+      image: rancher/os-docker:v0.4.0-dev
+      labels:
+        io.rancher.os.scope: system
+      links:
+      - cloud-init
+      - network
+      net: host
+      uts: host
+      pid: host
+      ipc: host
+      privileged: true
+      restart: always
+      volumes_from:
+      - all-volumes
+    docker-volumes:
+      image: rancher/os-state:v0.4.0-dev
+      labels:
+        io.rancher.os.createonly: true
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+      read_only: true
+      volumes:
+      - /var/lib/rancher/conf:/var/lib/rancher/conf
+      - /var/lib/docker:/var/lib/docker
+      - /var/lib/system-docker:/var/lib/system-docker
+    dockerwait:
+      image: rancher/os-dockerwait:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      links:
+      - docker
+      net: host
+      uts: host
+      volumes_from:
+      - all-volumes
+    network:
+      image: rancher/os-network:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      links:
+      - cloud-init-pre
+      net: host
+      uts: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    ntp:
+      image: rancher/os-ntp:v0.4.0-dev
+      labels:
+        io.rancher.os.scope: system
+      links:
+      - cloud-init
+      - network
+      net: host
+      uts: host
+      privileged: true
+      restart: always
+    preload-system-images:
+      image: rancher/os-preload:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      privileged: true
+      volumes:
+      - /var/run/system-docker.sock:/var/run/docker.sock
+      - /var/lib/system-docker/preload:/mnt/preload
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    preload-user-images:
+      image: rancher/os-preload:v0.4.0-dev
+      labels:
+        io.rancher.os.detach: false
+        io.rancher.os.scope: system
+      links:
+      - dockerwait
+      privileged: true
+      volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/preload:/mnt/preload
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    syslog:
+      image: rancher/os-syslog:v0.4.0-dev
+      labels:
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: host
+      uts: host
+      privileged: true
+      restart: always
+      volumes_from:
+      - system-volumes
+    system-volumes:
+      image: rancher/os-state:v0.4.0-dev
+      labels:
+        io.rancher.os.createonly: true
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+      read_only: true
+      volumes:
+      - /dev:/host/dev
+      - /os-config.yml:/os-config.yml
+      - /var/lib/rancher:/var/lib/rancher
+      - /var/lib/rancher/conf:/var/lib/rancher/conf
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher
+      - /lib/modules:/lib/modules
+      - /lib/firmware:/lib/firmware
+      - /var/run:/var/run
+      - /var/log:/var/log
+    udev:
+      image: rancher/os-udev:v0.4.0-dev
+      environment:
+      - DAEMON=true
+      labels:
+        io.rancher.os.detach: true
+        io.rancher.os.scope: system
+      net: host
+      uts: host
+      privileged: true
+      restart: always
+      volumes_from:
+      - system-volumes
+    user-volumes:
+      image: rancher/os-state:v0.4.0-dev
+      labels:
+        io.rancher.os.createonly: true
+        io.rancher.os.scope: system
+      log_driver: json-file
+      net: none
+      privileged: true
+      read_only: true
+      volumes:
+      - /home:/home
+      - /opt:/opt
+  system_docker:
+    args: [docker, -d, --log-driver, syslog, -s, overlay, -b, docker-sys, --fixed-cidr,
+      172.18.42.1/16, --restart=false, -g, /var/lib/system-docker, -G, root,
+      -H, 'unix:///var/run/system-docker.sock', --userland-proxy=false]
+  upgrade:
+    url: https://releases.rancher.com/os/versions.yml
+    image: rancher/os
+  user_docker:
+    tls_args: [--tlsverify, --tlscacert=ca.pem, --tlscert=server-cert.pem, --tlskey=server-key.pem,
+      '-H=0.0.0.0:2376']
+    args: [docker, -d, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock', --userland-proxy=false]


### PR DESCRIPTION
Do not merge yet. 

A very obscure bug (and now traced) was causing `ros config get` to 
print out YAML unmarshaling errors instead of configuration values.
`c.readArgs()` usage is now commented out (config/config.ro:228), and I need to 
code the proper fix now. 

Currently, it finally compiles and runs, but needs cleanup. 