### PR TITLE
Return gracefully when `ros env` is called without argument(s)

### DIFF
--- a/cmd/control/env.go
+++ b/cmd/control/env.go
@@ -18,6 +18,9 @@ func envAction(c *cli.Context) {
 	}
 
 	args := c.Args()
+	if len(args) == 0 {
+		return
+	}
 	osEnv := os.Environ()
 
 	envMap := make(map[string]string, len(cfg.Rancher.Environment)+len(osEnv))


### PR DESCRIPTION
Fixes Runtime error issue #464 