### PR TITLE
update docker daemon params

### DIFF
--- a/os-config.yml
+++ b/os-config.yml
@@ -270,8 +270,8 @@ rancher:
       - /home:/home
       - /opt:/opt
   system_docker:
-    args: [-d, -s, overlay, -b, docker-sys, --fixed-cidr, 172.18.42.1/16,
-      --restart=false, -g, /var/lib/system-docker, -G, root,
+    args: [daemon, --log-opt, max-size=10m, --log-opt, max-file=10, -s, overlay, -b, docker-sys,
+      --fixed-cidr, 172.18.42.1/16, --restart=false, -g, /var/lib/system-docker, -G, root,
       -H, 'unix:///var/run/system-docker.sock', --userland-proxy=false]
   upgrade:
     url: https://releases.rancher.com/os/versions.yml
@@ -279,4 +279,4 @@ rancher:
   user_docker:
     tls_args: [--tlsverify, --tlscacert=ca.pem, --tlscert=server-cert.pem, --tlskey=server-key.pem,
       '-H=0.0.0.0:2376']
-    args: [-d, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock', --userland-proxy=false]
+    args: [daemon, --log-opt, max-size=10m, --log-opt, max-file=10, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock', --userland-proxy=false]


### PR DESCRIPTION
update docker daemon params

- use `daemon` instead of the deprecated `-d`
- use rollover logging