### PR TITLE
less panics and fatals

### DIFF
--- a/cmd/cloudinit/authorize_ssh_keys.go
+++ b/cmd/cloudinit/authorize_ssh_keys.go
@@ -14,7 +14,7 @@ func authorizeSSHKeys(user string, authorizedKeys []string, name string) {
 		cmd.Stderr = os.Stderr
 		err := cmd.Run()
 		if err != nil {
-			log.Fatal(err.Error())
+			log.WithFields(log.Fields{"err": err, "user": user, "auth_key": authorizedKey}).Error("Error updating SSH authorized_keys")
 		}
 	}
 }

--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -100,7 +100,8 @@ func saveFiles(cloudConfigBytes, scriptBytes []byte, metadata datasource.Metadat
 func currentDatasource() (datasource.Datasource, error) {
 	cfg, err := rancherConfig.LoadConfig()
 	if err != nil {
-		log.Fatalf("Failed to read rancher config %v", err)
+		log.WithFields(log.Fields{"err": err}).Error("Failed to read rancher config")
+		return nil, err
 	}
 
 	dss := getDatasources(cfg)
@@ -275,7 +276,7 @@ func executeCloudConfig() error {
 	if cc.Hostname != "" {
 		//set hostname
 		if err := hostname.SetHostname(cc.Hostname); err != nil {
-			log.Fatal(err)
+			log.WithFields(log.Fields{"err": err, "hostname": cc.Hostname}).Error("Error setting hostname")
 		}
 	}
 
@@ -297,7 +298,8 @@ func executeCloudConfig() error {
 		f := system.File{File: file}
 		fullPath, err := system.WriteFile(&f, "/")
 		if err != nil {
-			log.Fatal(err)
+			log.WithFields(log.Fields{"err": err, "path": fullPath}).Error("Error writing file")
+			continue
 		}
 		log.Printf("Wrote file %s to filesystem", fullPath)
 	}

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -165,12 +165,12 @@ func configGet(c *cli.Context) {
 
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		log.Panicln(err)
+		log.WithFields(log.Fields{"err": err}).Fatal("config get: failed to load config")
 	}
 
 	val, err := cfg.Get(arg)
 	if err != nil {
-		log.WithFields(log.Fields{"cfg": cfg, "arg": arg, "val": val}).Panicln(err)
+		log.WithFields(log.Fields{"cfg": cfg, "key": arg, "val": val, "err": err}).Fatal("config get: failed to retrieve value")
 	}
 
 	printYaml := false

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -101,7 +101,7 @@ func imagesFromConfig(cfg *config.CloudConfig) []string {
 
 func runImages(c *cli.Context) {
 	configFile := c.String("input")
-	cfg := config.ReadConfig(configFile)
+	cfg := config.ReadConfig(nil, configFile)
 	if cfg == nil {
 		log.Fatalf("Could not read config from file %v", configFile)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,10 @@ func LoadConfig() (*CloudConfig, error) {
 }
 
 func (c *CloudConfig) merge(values map[interface{}]interface{}) error {
+	t := &CloudConfig{}
+	if err := util.Convert(values, t); err != nil {
+		return err
+	}
 	return util.Convert(values, c)
 }
 

--- a/config/default.go
+++ b/config/default.go
@@ -1,13 +1,15 @@
 package config
 
 func NewConfig() *CloudConfig {
-	return ReadConfig(OsConfigFile)
+	return ReadConfig(nil, OsConfigFile)
 }
 
-func ReadConfig(file string) *CloudConfig {
-	if data, err := readConfig(nil, file); err == nil {
+func ReadConfig(bytes []byte, files ...string) *CloudConfig {
+	if data, err := readConfig(bytes, files...); err == nil {
 		c := &CloudConfig{}
-		c.merge(data)
+		if err := c.merge(data); err != nil {
+			return nil
+		}
 		c.amendNils()
 		return c
 	} else {

--- a/init/init.go
+++ b/init/init.go
@@ -168,8 +168,10 @@ func RunInit() error {
 			}
 
 			if cfg.Rancher.Debug {
-				cfgString, _ := config.Dump(false, true)
-				if cfgString != "" {
+				cfgString, err := config.Dump(false, true)
+				if err != nil {
+					log.WithFields(log.Fields{"err": err}).Error("Error serializing config")
+				} else {
 					log.Debugf("Config: %s", cfgString)
 				}
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -155,7 +155,7 @@ func RandSeq(n int) string {
 func Convert(from, to interface{}) error {
 	bytes, err := yaml.Marshal(from)
 	if err != nil {
-		log.WithFields(log.Fields{"from": from}).Panicln(err)
+		log.WithFields(log.Fields{"from": from, "err": err}).Warn("Error serializing to YML")
 		return err
 	}
 


### PR DESCRIPTION
Don't throw panics where logging fatal or error would do.
Don't save bad cloud-config.
Don't abort cloud-init on configuration errors, only report them.