### PR TITLE
Fix sha1sum call to work on both Linux and Darwin.

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -7,16 +7,21 @@ cd $(dirname $0)/..
 source scripts/build-common
 
 BASE=$(pwd)
+UNAME=$(uname)
+
+# Linux and Darwin SHA1 sum binary are different, pick which to use
+if [ "$UNAME" == "Darwin" ]; then sha1sum=$(which shasum)
+elif [ "$UNAME" == "Linux" ]; then sha1sum=$(which sha1sum);
+fi
 
 KERNEL=${BASE}/dist/artifacts/vmlinuz
 INITRD=${BASE}/dist/artifacts/initrd
 NO_COMPRESS_INITRD=${INITRD}.none
 HD=${BASE}/state/empty-hd.img
 HD_GZ=${BASE}/assets/empty-hd.img.gz
-INITRD_TMP=${BUILD}/$(sha1sum ${INITRD} | awk '{print $1}')
+INITRD_TMP=${BUILD}/$(${sha1sum} ${INITRD} | awk '{print $1}')
 INITRD_CURRENT=${BUILD}/initrd-current
 INITRD_TEST=${BUILD}/initrd.test
-UNAME=$(uname)
 USER_DATA=cloud-init/openstack/latest/user_data
 
 # PREREQ: brew install coreutils


### PR DESCRIPTION
When running `scripts/run` on Darwin the xhyve boot process fails due to a missing root device. This is because `sha1sum` is called to generate a temp folder using the SHA1 hash of `dist/artifacts/initrd`  as its name. This temp folder is then used to generate the Rancher OS `initrd.test` to boot xhyve. Since `sha1sum` is named `shasum` on Darwin the command fails and `$INITRD_TMP` is set to `./build` instead and the generated `initrd.test` file is unbootable. This PR fixes the issue by setting `sha1sum` to the result of `which sha1sum` for Linux hosts and the result of `which shasum` for Darwin hosts. Tested and working as intended on a clean 10.10.5 host.