### PR TITLE
mark default console as ephemeral (rebuild: always)

### DIFF
--- a/os-config.yml
+++ b/os-config.yml
@@ -138,6 +138,7 @@ rancher:
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: cloud-init
+        io.docker.compose.rebuild: always
       net: host
       uts: host
       pid: host


### PR DESCRIPTION
WIP: service rebuild logic

Affects how services get rebuilt and how "persistent" containers are configured.