### PR TITLE
Fixed 32-bit issue in power.go

### DIFF
--- a/cmd/power/power.go
+++ b/cmd/power/power.go
@@ -129,7 +129,7 @@ func Halt() {
 	reboot(syscall.LINUX_REBOOT_CMD_HALT)
 }
 
-func reboot(code int) {
+func reboot(code uint) {
 	err := shutDownContainers()
 	if err != nil {
 		log.Error(err)
@@ -137,7 +137,7 @@ func reboot(code int) {
 
 	syscall.Sync()
 
-	err = syscall.Reboot(code)
+	err = syscall.Reboot(int(code))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hello,

Here is a fix to #520.

I haven't tested it on a 64-bit machine, but you may know if it is save to merge.

I would think so, just a small conversion.

Another possibility is to make a 32bit experiment branch, which I would prefer.