### PR TITLE
fix: `scripts/run --qind` runs plain qemu (instead of qind)

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -36,6 +36,7 @@ while [ "$#" -gt 0 ]; do
         --xhyve)
             if [ -x $(which xhyve) ]; then
                 XHYVE=1
+                QEMU=0
             fi
             ;;
         --qemu)
@@ -45,6 +46,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         --qind)
             QIND=1
+            QEMU=0
             ;;
         --kvm)
             KVM=1

--- a/scripts/ssh
+++ b/scripts/ssh
@@ -20,12 +20,14 @@ while [ "$#" -gt 0 ]; do
             ;;
         --xhyve)
             XHYVE=1
+            QEMU=0
             ;;
         --qemu)
             QEMU=1
             ;;
         --qind)
             QIND=1
+            QEMU=0
             ;;
         --key)
             shift 1


### PR DESCRIPTION
fix: `scripts/run --qind` runs plain qemu (instead of qind)