### PR TITLE
Make godep executable configurable in Makefile.docker

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,11 +1,12 @@
 include build.conf
 FORCE_PULL := 0
 DEV_BUILD  := 0
+GODEP := godep
 
 
 bin/rancheros:
 	mkdir -p $(dir $@)
-	godep go build -tags netgo -installsuffix netgo -ldflags "-X github.com/rancherio/os/config.VERSION $(VERSION) -linkmode external -extldflags -static" -o $@
+	$(GODEP) go build -tags netgo -installsuffix netgo -ldflags "-X github.com/rancherio/os/config.VERSION $(VERSION) -linkmode external -extldflags -static" -o $@
 	strip --strip-all $@
 
 


### PR DESCRIPTION
This makes it so that I can run `make GODEP= -f Makefile.docker bin/rancheros` which helps with my development flow.