### PR TITLE
installer: copy 1M zeroes to the target device before running fdisk

### DIFF
--- a/scripts/installer/set-disk-partitions
+++ b/scripts/installer/set-disk-partitions
@@ -28,10 +28,10 @@ if [ "$PARTITION_COUNT" -gt "1" ]; then
             exit 1
         fi
     done
-
-    dd if=/dev/zero of=${DEVICE} bs=512 count=1
-    partprobe ${DEVICE}
 fi
+
+dd if=/dev/zero of=${DEVICE} bs=512 count=2048
+partprobe ${DEVICE}
 
 fdisk ${DEVICE} <<EOF
 n

--- a/tests/integration/rancherostest/test_03_docker_in_persistent_console.py
+++ b/tests/integration/rancherostest/test_03_docker_in_persistent_console.py
@@ -1,7 +1,6 @@
 import pytest
 import rancherostest.util as u
 import subprocess
-import yaml
 
 
 ssh_command = ['./scripts/ssh', '--qemu', '--key', './tests/integration/assets/test.key']
@@ -11,11 +10,6 @@ cloud_config_path = './tests/integration/assets/test_03/cloud-config.yml'
 @pytest.fixture(scope="module")
 def qemu(request):
     return u.run_qemu(request, ['--cloud-config', cloud_config_path])
-
-
-@pytest.fixture(scope="module")
-def cloud_config():
-    return yaml.load(open(cloud_config_path))
 
 
 @pytest.mark.timeout(40)

--- a/tests/integration/rancherostest/test_04_ros_install.py
+++ b/tests/integration/rancherostest/test_04_ros_install.py
@@ -1,0 +1,28 @@
+import pytest
+import rancherostest.util as u
+import subprocess
+
+
+ssh_command = ['./scripts/ssh', '--qemu']
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    return u.run_qemu(request, ['--no-format'])
+
+
+@pytest.mark.timeout(40)
+def test_ros_install_on_formatted_disk(qemu):
+    assert qemu is not None
+    u.wait_for_ssh(ssh_command)
+    subprocess.check_call(ssh_command + ['sudo', 'mkfs.ext4', '/dev/vda'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.check_call(ssh_command + ['sudo', 'ros', 'install', '-f', '--no-reboot', '-d', '/dev/vda',
+                                         '-i', 'rancher/os:v0.4.0-dev-test.135'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.call(ssh_command + ['sudo', 'reboot'],
+                    stderr=subprocess.STDOUT, universal_newlines=True)
+
+    u.wait_for_ssh(ssh_command)


### PR DESCRIPTION
Installer: copy 1M zeroes to the target device before running fdisk.

Otherwise grub-install chokes, even after the new partition table has been created.

Should fix #135