### PR TITLE
WIP: Show logs with no previous tail

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/libcompose/docker/container.go
+++ b/Godeps/_workspace/src/github.com/docker/libcompose/docker/container.go
@@ -420,7 +420,7 @@ func (c *Container) Log() error {
 		Follow: true,
 		Stdout: true,
 		Stderr: true,
-		Tail:   10,
+		Tail:   0,
 	})
 	if err != nil {
 		return err

--- a/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
+++ b/Godeps/_workspace/src/github.com/samalba/dockerclient/dockerclient.go
@@ -200,7 +200,7 @@ func (client *DockerClient) ContainerLogs(id string, options *LogOptions) (io.Re
 	v.Add("stdout", strconv.FormatBool(options.Stdout))
 	v.Add("stderr", strconv.FormatBool(options.Stderr))
 	v.Add("timestamps", strconv.FormatBool(options.Timestamps))
-	if options.Tail > 0 {
+	if options.Tail >= 0 {
 		v.Add("tail", strconv.FormatInt(options.Tail, 10))
 	}
 


### PR DESCRIPTION
WIP: Show logs with no previous tail

So that service logs from previous boots do not appear in the current boot logs.
WIP, Godeps update needed.