### PR TITLE
Delete the unused const variable in docker/client.go

### DIFF
--- a/docker/client.go
+++ b/docker/client.go
@@ -5,11 +5,6 @@ import (
 	"github.com/rancher/os/config"
 )
 
-const (
-	MAX_WAIT = 30000
-	INTERVAL = 100
-)
-
 func NewSystemClient() (*dockerClient.Client, error) {
 	return NewClient(config.DOCKER_SYSTEM_HOST)
 }


### PR DESCRIPTION
The commit 9d76b79ac36e87965 refactor code for function
"NewClient", and we should delete the unused const
variable.

Signed-off-by: Wang Long <long.wanglong@huawei.com>