### PR TITLE
config/types.go: add "" to field tag

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -52,12 +52,12 @@ type ContainerConfig struct {
 	Cmd            string                 `yaml:"run,omitempty"`
 	MigrateVolumes bool                   `yaml:"migrate_volumes,omitempty"`
 	ReloadConfig   bool                   `yaml:"reload_config,omitempty"`
-	CreateOnly     bool                   `yaml:create_only,omitempty`
-	Service        *project.ServiceConfig `yaml:service,omitempty`
+	CreateOnly     bool                   `yaml:"create_only,omitempty"`
+	Service        *project.ServiceConfig `yaml:"service,omitempty"`
 }
 
 type Repository struct {
-	Url string `yaml:url,omitempty`
+	Url string `yaml:"url,omitempty"`
 }
 
 type Repositories map[string]Repository

--- a/config/types.go
+++ b/config/types.go
@@ -47,15 +47,6 @@ func init() {
 	}
 }
 
-type ContainerConfig struct {
-	Id             string                 `yaml:"id,omitempty"`
-	Cmd            string                 `yaml:"run,omitempty"`
-	MigrateVolumes bool                   `yaml:"migrate_volumes,omitempty"`
-	ReloadConfig   bool                   `yaml:"reload_config,omitempty"`
-	CreateOnly     bool                   `yaml:"create_only,omitempty"`
-	Service        *project.ServiceConfig `yaml:"service,omitempty"`
-}
-
 type Repository struct {
 	Url string `yaml:"url,omitempty"`
 }


### PR DESCRIPTION
The field tag format accepted is[1]:
    `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
so we should add double quotation marks for the
filed tag format.

[1]: https://godoc.org/gopkg.in/yaml.v2

Signed-off-by: Wang Long <long.wanglong@huawei.com>