### PR TITLE
Always use bundled docker for system-docker.

### DIFF
--- a/cmd/systemdocker/system-docker.go
+++ b/cmd/systemdocker/system-docker.go
@@ -19,7 +19,7 @@ func Main() {
 
 	newEnv = append(newEnv, "DOCKER_HOST="+config.DOCKER_SYSTEM_HOST)
 
-	os.Args[0] = "/usr/bin/docker.dist"
+	os.Args[0] = config.DOCKER_DIST_BIN
 	if err := syscall.Exec(os.Args[0], os.Args, newEnv); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/systemdocker/system-docker.go
+++ b/cmd/systemdocker/system-docker.go
@@ -19,7 +19,7 @@ func Main() {
 
 	newEnv = append(newEnv, "DOCKER_HOST="+config.DOCKER_SYSTEM_HOST)
 
-	os.Args[0] = "/usr/bin/docker"
+	os.Args[0] = "/usr/bin/docker.dist"
 	if err := syscall.Exec(os.Args[0], os.Args, newEnv); err != nil {
 		log.Fatal(err)
 	}

--- a/config/types.go
+++ b/config/types.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	DOCKER_BIN         = "/usr/bin/docker"
+	DOCKER_DIST_BIN    = "/usr/bin/docker.dist"
 	ROS_BIN            = "/usr/bin/ros"
 	SYSINIT_BIN        = "/usr/bin/ros-sysinit"
 	DOCKER_SYSTEM_HOME = "/var/lib/system-docker"

--- a/tests/integration/assets/test_05/cloud-config.yml
+++ b/tests/integration/assets/test_05/cloud-config.yml
@@ -1,0 +1,6 @@
+#cloud-config
+rancher:
+  services_include:
+    debian-console: true
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUlsWAL5Rf0Wis/A7k7Tlqx0fZS60VzCZrPZYbP/wkL95jv0XzCx8bd1rZHeybblHPDNpND3BLv4qPY5DxRyexF4seGuzcJI/pOvGUGjQondeMPgDTFEo5w939gSdeTZcfXzQ0wAVhzwDbgH4zPfMzbdoo8Aiu9jkKljXw8IFju0gh+t6iKkGZCIjKT9o7zza1vGfkodhvi2V3VzPdNO28gaxZaRNtmBYUoVnGyR6nXN1Q3CJaVuh5o6GPCOqrhHNbYOFZKBpDiHbxPhVpxHQD2+8yUSGTG7WW75FfZePja5y8d0c/O5L37ZYx4AZAd3KgQYDBT2XCEJGQNawNbfpt

--- a/tests/integration/rancherostest/test_05_custom_docker_in_persistent_console.py
+++ b/tests/integration/rancherostest/test_05_custom_docker_in_persistent_console.py
@@ -1,0 +1,38 @@
+import pytest
+import rancherostest.util as u
+import subprocess
+import time
+
+
+ssh_command = ['./scripts/ssh', '--qemu', '--key', './tests/integration/assets/test.key']
+cloud_config_path = './tests/integration/assets/test_05/cloud-config.yml'
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    return u.run_qemu(request, ['--cloud-config', cloud_config_path])
+
+
+@pytest.mark.timeout(40)
+def test_system_docker_survives_custom_docker_install(qemu):
+    assert qemu is not None
+    u.wait_for_ssh(ssh_command)
+    subprocess.check_call(ssh_command + ['curl', '-OL',
+                                         'https://test.docker.com/builds/Linux/x86_64/docker-1.9.0-rc4'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.check_call(ssh_command + ['chmod', '+x', '/home/rancher/docker-1.9.0-rc4'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.check_call(ssh_command + ['sudo', 'ln', '-sf', '/home/rancher/docker-1.9.0-rc4', '/usr/bin/docker'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.check_call(ssh_command + ['sudo', 'system-docker', 'restart', 'docker'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+
+    subprocess.check_call(ssh_command + ['sudo', 'system-docker', 'version'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)
+    time.sleep(3)
+
+    subprocess.check_call(ssh_command + ['docker', 'version'],
+                          stderr=subprocess.STDOUT, universal_newlines=True)


### PR DESCRIPTION
Always use bundled docker for system-docker.

Fixes system-docker CLI breaking after a newer custom docker has been installed into the console container (e.g. into debian-console).