### PR TITLE
system-docker: replace /usr/bin/docker with DOCKER_BIN

### DIFF
--- a/cmd/systemdocker/system-docker.go
+++ b/cmd/systemdocker/system-docker.go
@@ -19,7 +19,7 @@ func Main() {
 
 	newEnv = append(newEnv, "DOCKER_HOST="+config.DOCKER_SYSTEM_HOST)
 
-	os.Args[0] = "/usr/bin/docker"
+	os.Args[0] = config.DOCKER_BIN
 	if err := syscall.Exec(os.Args[0], os.Args, newEnv); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It is better to use const DOCKER_BIN.

Signed-off-by: Wang Long <long.wanglong@huawei.com>