### PR TITLE
Adding default username and password in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ it would really be bad if somebody did `docker rm -f $(docker ps -qa)` and delet
 https://releases.rancher.com/os/latest/rancheros.iso  
 https://releases.rancher.com/os/v0.4.0/rancheros.iso  
 
+**Note**: you must login using `rancher` for username and password.
+
 ### Additional Downloads
 
 https://releases.rancher.com/os/latest/initrd


### PR DESCRIPTION
Adding default username and password in readme. This will help the users to log when they boot the downloaded image.
Added this comment since I had troubles finding it through the doccumentation. endend using `grep -r password os` to realize that password is set in scripts/isolinux.cfg.  I asked the password in the IRC #rancher early today, and I realize other user had the same issue yesterday.