### PR TITLE
Avoid hardcoded reference to /scripts

### DIFF
--- a/scripts/installer/lay-down-os
+++ b/scripts/installer/lay-down-os
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e -x
 
-. $(dirname $0)/build.conf
+SCRIPTS_DIR=$(dirname ${0})
+
+. "${SCRIPTS_DIR}/build.conf"
 VERSION=${VERSION:?"VERSION not set"}
 
 while getopts "i:f:c:d:t:r:o:p:" OPTION
@@ -20,7 +22,7 @@ do
 done
 
 DIST=${DIST:-/dist}
-CLOUD_CONFIG=${CLOUD_CONFIG:-/scripts/conf/empty.yml}
+CLOUD_CONFIG=${CLOUD_CONFIG:-"${SCRIPTS_DIR}/conf/empty.yml"}
 CONSOLE=tty0
 BASE_DIR="/mnt/new_img"
 # TODO: Change this to a number so that users can specify.
@@ -148,7 +150,7 @@ if [ -n ${ENV} ]; then
         "generic")
             format_and_mount
             install_grub
-            /scripts/seed-data ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
+            "${SCRIPTS_DIR}/seed-data" ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
             ;;
         "amazon-ebs-pv"|"amazon-ebs-hvm")
             CONSOLE=ttyS0
@@ -157,13 +159,13 @@ if [ -n ${ENV} ]; then
                 install_grub
             fi
             # AWS Networking recommends disabling.
-            /scripts/seed-data ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
+            "${SCRIPTS_DIR}/seed-data" ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
             ;;
         "googlecompute")
             CONSOLE=ttyS0
             format_and_mount
             install_grub
-            /scripts/seed-data ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
+            "${SCRIPTS_DIR}/seed-data" ${BASE_DIR} ${CLOUD_CONFIG} ${FILES}
             ;;
         "bootstrap")
             CONSOLE=ttyS0

--- a/scripts/installer/seed-data
+++ b/scripts/installer/seed-data
@@ -2,6 +2,8 @@
 
 set -e -x
 
+SCRIPTS_DIR=$(dirname ${0})
+
 BASE_DIR=${1}
 CLOUD_DATA=${2}
 IFS=',' read -ra FILES <<< "${3}"
@@ -12,7 +14,7 @@ if [ -z ${BASE_DIR} ]; then
 fi
 
 mkdir -p ${BASE_DIR}/var/lib/rancher/conf/cloud-config.d
-if [ "$CLOUD_DATA" != "/scripts/conf/empty.yml" ]; then
+if [ "${CLOUD_DATA}" != "${SCRIPTS_DIR}/conf/empty.yml" ]; then
     cp ${CLOUD_DATA} ${BASE_DIR}/var/lib/rancher/conf/cloud-config.d/
 fi
 


### PR DESCRIPTION
Within a custom provisioning script, I found myself manually running `lay-down-os`, when I discovered it depends on the existence of the `/scripts` directory, which I did not have.

Here's my proposal to avoid this by determining the scripts dir as the one containing `lay-down-os`. To prevent a behaviour change in `seed-data`, I had to modify this script as well.

Please let me know if you have any remarks. Thanks!