### PR TITLE
Configure DNS nameservers with DHCP or cloud-config

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -368,7 +368,7 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/netconf",
-			"Rev": "b9aeb623c8ef9551d79efec57ee059658c1ac89c"
+			"Rev": "02925e7cf5a0f0bb0aa5360ee260ef7378e5eff8"
 		},
 		{
 			"ImportPath": "github.com/ryanuber/go-glob",

--- a/Godeps/_workspace/src/github.com/rancher/netconf/types.go
+++ b/Godeps/_workspace/src/github.com/rancher/netconf/types.go
@@ -16,6 +16,7 @@ type InterfaceConfig struct {
 }
 
 type DnsConfig struct {
+	Override    bool     `yaml:"override"`
 	Nameservers []string `yaml:"nameservers,flow,omitempty"`
 	Search      []string `yaml:"search,flow,omitempty"`
 }

--- a/os-config.yml
+++ b/os-config.yml
@@ -244,6 +244,7 @@ rancher:
       volumes:
       - /dev:/host/dev
       - /etc/docker:/etc/docker
+      - /etc/resolv.conf:/etc/resolv.conf
       - /etc/rkt:/etc/rkt
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher
       - /lib/firmware:/lib/firmware


### PR DESCRIPTION
Allow network service to automatically configure DNS from DHCP (by default). 
This can be overridden and configured with values from cloud-config. 