### PR TITLE
Fix naming of external services (e.g. specified by rancher.services_include)

### DIFF
--- a/compose/project.go
+++ b/compose/project.go
@@ -94,6 +94,19 @@ func addServices(p *project.Project, enabled map[interface{}]interface{}, config
 	return enabled
 }
 
+func adjustContainerNames(m map[interface{}]interface{}) map[interface{}]interface{} {
+	for k, v := range m {
+		if k, ok := k.(string); ok {
+			if v, ok := v.(map[interface{}]interface{}); ok {
+				if _, ok := v["container_name"]; !ok {
+					v["container_name"] = k
+				}
+			}
+		}
+	}
+	return m
+}
+
 func newCoreServiceProject(cfg *config.CloudConfig, network bool) (*project.Project, error) {
 	projectEvents := make(chan project.Event)
 	enabled := map[interface{}]interface{}{}
@@ -135,7 +148,7 @@ func newCoreServiceProject(cfg *config.CloudConfig, network bool) (*project.Proj
 				log.Errorf("Failed to parse YAML configuration: %s : %v", service, err)
 				continue
 			}
-			bytes, err = yaml.Marshal(config.StringifyValues(m))
+			bytes, err = yaml.Marshal(adjustContainerNames(config.StringifyValues(m)))
 			if err != nil {
 				log.Errorf("Failed to marshal YAML configuration: %s : %v", service, err)
 				continue

--- a/config/disk.go
+++ b/config/disk.go
@@ -194,7 +194,6 @@ func amendContainerNames(c *CloudConfig) (*CloudConfig, error) {
 		c.Rancher.Services,
 	} {
 		for k, v := range scm {
-			v.Name = k
 			v.ContainerName = k
 		}
 	}

--- a/tests/integration/assets/test_01/cloud-config.yml
+++ b/tests/integration/assets/test_01/cloud-config.yml
@@ -3,6 +3,8 @@ rancher:
   environment:
     ETCD_DISCOVERY: https://discovery.etcd.io/c2c219023108cda9529364d6d983fe13
     FLANNEL_NETWORK: 10.244.0.0/16
+  services_include:
+    kernel-headers: true
   network:
     interfaces:
       eth1:

--- a/tests/integration/rostest/test_01_cloud_config.py
+++ b/tests/integration/rostest/test_01_cloud_config.py
@@ -64,6 +64,11 @@ def test_dhcpcd(qemu, cloud_config):
 
 
 @pytest.mark.timeout(40)
+def test_services_include(qemu, cloud_config):
+    u.wait_for_ssh(qemu, ssh_command, ['docker inspect kernel-headers >/dev/null 2>&1'])
+
+
+@pytest.mark.timeout(40)
 def test_docker_tls_args(qemu, cloud_config):
     u.wait_for_ssh(qemu, ssh_command)
 

--- a/tests/integration/rostest/util.py
+++ b/tests/integration/rostest/util.py
@@ -76,11 +76,11 @@ def flush_out(stdout, substr='RancherOS '):
 
 
 @pytest.mark.timeout(10)
-def wait_for_ssh(qemu, ssh_command=['./scripts/ssh', '--qemu']):
+def wait_for_ssh(qemu, ssh_command=['./scripts/ssh', '--qemu'], command=['docker version >/dev/null 2>&1']):
     i = 0
     assert qemu.returncode is None
     print('\nWaiting for ssh and docker... ' + str(i))
-    while subprocess.call(ssh_command + ['docker version >/dev/null 2>&1']) != 0:
+    while subprocess.call(ssh_command + command) != 0:
         i += 1
         print('\nWaiting for ssh and docker... ' + str(i))
         time.sleep(1)


### PR DESCRIPTION
Fix naming of external services (e.g. specified by rancher.services_include)

Add name and container_name keys to service configurations.