### PR TITLE
 Farewell PID one

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -1,6 +1,6 @@
 IMAGE_NAME=rancher/os
 VERSION=v0.4.3-dev
 
-DOCKER_BINARY_URL=https://github.com/rancher/docker/releases/download/v1.9.1-ros1/docker-1.9.1
+DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.9.1
 COMPILED_KERNEL_URL=https://github.com/rancher/os-kernel/releases/download/Ubuntu-4.2.0-16.19/linux-4.2.3-rancher-x86.tar.gz
 DFS_IMAGE=rancher/docker:1.9.1-2

--- a/config/types.go
+++ b/config/types.go
@@ -101,6 +101,7 @@ type DockerConfig struct {
 	CAKey          string   `yaml:"ca_key,omitempty"`
 	Environment    []string `yaml:"environment,omitempty"`
 	StorageContext string   `yaml:"storage_context,omitempty"`
+	Exec           bool     `yaml:"exec,omitempty"`
 }
 
 type StateConfig struct {

--- a/init/init.go
+++ b/init/init.go
@@ -194,8 +194,12 @@ func RunInit() error {
 	}
 
 	launchConfig, args := getLaunchConfig(cfg, &cfg.Rancher.SystemDocker)
+	launchConfig.Fork = !cfg.Rancher.SystemDocker.Exec
 
 	log.Info("Launching System Docker")
 	_, err = dockerlaunch.LaunchDocker(launchConfig, config.DOCKER_BIN, args...)
-	return err
+	if err != nil {
+		return err
+	}
+	return pidOne()
 }

--- a/init/one.go
+++ b/init/one.go
@@ -1,0 +1,28 @@
+// +build linux
+
+package init
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func pidOne() error {
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGCHLD)
+
+	var (
+		ws  syscall.WaitStatus
+		rus syscall.Rusage
+	)
+	for range c {
+		for {
+			if pid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, &rus); err != nil || pid <= 0 {
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/tests/integration/rostest/test_01_cloud_config.py
+++ b/tests/integration/rostest/test_01_cloud_config.py
@@ -3,6 +3,7 @@ import subprocess
 
 import pytest
 import rostest.util as u
+from rostest.util import SSH
 import yaml
 
 ssh_command = ['./scripts/ssh', '--qemu', '--key', './tests/integration/assets/test.key']
@@ -91,3 +92,12 @@ def test_rancher_network(qemu, cloud_config):
 
     assert v.split(' ')[2] == 'eth1'
     assert v.split(' ')[5] + '/24' == cloud_config['rancher']['network']['interfaces']['eth1']['address']
+
+
+def test_docker_not_pid_one(qemu):
+    SSH(qemu, ssh_command=ssh_command).check_call('bash', '-c', '''
+    set -e -x
+    for i in $(pidof docker); do
+        [ $i != 1 ]
+    done
+    '''.strip())

--- a/tests/integration/rostest/util.py
+++ b/tests/integration/rostest/util.py
@@ -84,6 +84,8 @@ def wait_for_ssh(qemu, ssh_command=['./scripts/ssh', '--qemu'], command=['docker
         i += 1
         print('\nWaiting for ssh and docker... ' + str(i))
         time.sleep(1)
+        if i > 60:
+            raise 'Failed to connect to SSH'
         assert qemu.returncode is None
 
 


### PR DESCRIPTION
This change no longer runs Docker as PID 1.  Instead PID 1 is a very
simple zombie reaper and Docker is moved as a child of that PID.