### PR TITLE
Multi-arch build: amd64, arm

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,9 +1,9 @@
-FROM debian:jessie
+FROM ubuntu:15.10
+
 RUN apt-get update && \
     apt-get -y install locales sudo vim less curl wget git rsync build-essential syslinux isolinux xorriso \
-        libblkid-dev libmount-dev libselinux1-dev cpio genisoimage qemu-kvm python-pip ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/genisoimage /usr/bin/mkisofs
+        libblkid-dev libmount-dev libselinux1-dev cpio genisoimage qemu-kvm python-pip ca-certificates
+
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV PATH $PATH:/usr/local/go/bin
@@ -14,8 +14,8 @@ ENV GO15VENDOREXPERIMENT 1
 
 RUN pip install tox
 RUN curl -sSL https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz | tar -xz -C /usr/local
-RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker
-RUN chmod +x /usr/bin/docker
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/local/bin/docker
+RUN chmod +x /usr/local/bin/docker
 
 ENV DAPPER_DOCKER_SOCKET true
 ENV DAPPER_SOURCE /go/src/github.com/rancher/os
@@ -25,3 +25,33 @@ ENV SHELL /bin/bash
 WORKDIR ${DAPPER_SOURCE}
 
 COPY .dockerignore.docker .dockerignore
+
+RUN cd /usr/local/src && \
+    for i in libselinux pcre3 util-linux; do \
+        apt-get build-dep -y $i && \
+        apt-get source -y $i \
+    ;done
+
+RUN apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+RUN cd /usr/local/src/pcre3-* && \
+    autoreconf && \
+    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ ./configure --host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf && \
+    make -j$(nproc) && \
+    make install
+
+RUN cd /usr/local/src/libselinux-* && \
+    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ make CFLAGS=-Wall && \
+    make PREFIX=/usr/arm-linux-gnueabihf DESTDIR=/usr/arm-linux-gnueabihf install
+
+RUN cd /usr/local/src/util-linux-* && \
+    autoreconf && \
+    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ ./configure --host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf \
+        --disable-all-programs \
+        --enable-libmount \
+        --enable-libblkid \
+        --enable-libuuid \
+        --enable-mount && \
+    make -j$(nproc) && \
+    make install
+
+CMD make all

--- a/build.conf
+++ b/build.conf
@@ -1,6 +1,3 @@
 IMAGE_NAME=rancher/os
 VERSION=v0.4.3-dev
-
-DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.0
-COMPILED_KERNEL_URL=https://github.com/rancher/os-kernel/releases/download/Ubuntu-4.2.0-28.33-rancher/linux-4.2.8-ckt3-rancher-x86.tar.gz
 DFS_IMAGE=rancher/docker:1.10.0

--- a/build.conf.amd64
+++ b/build.conf.amd64
@@ -1,0 +1,2 @@
+COMPILED_KERNEL_URL=https://github.com/rancher/os-kernel/releases/download/Ubuntu-4.2.0-28.33-rancher/linux-4.2.8-ckt3-rancher-x86.tar.gz
+DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.0

--- a/build.conf.arm
+++ b/build.conf.arm
@@ -1,0 +1,1 @@
+DOCKER_BINARY_URL=https://github.com/rancher/docker/releases/download/v1.10.0-ros_arm/docker-1.10.0

--- a/build.sh
+++ b/build.sh
@@ -8,9 +8,9 @@ if [ "$1" != "--dev" ]; then
   echo
   echo For \"developer\" builds, run ./build.sh --dev
   echo
-  dapper -k make all
+  dapper make all
 else
-  dapper -k make DEV_BUILD=1 all
+  dapper make DEV_BUILD=1 all
 fi
 
 

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"os"
 	"syscall"
 
 	"fmt"
@@ -61,7 +60,7 @@ func stopDocker(c chan interface{}) error {
 	c <- struct{}{}
 	<-c
 
-	return os.RemoveAll(config.DOCKER_SYSTEM_HOME)
+	return nil
 }
 
 func bootstrap(cfg *config.CloudConfig) error {

--- a/init/sysinit.go
+++ b/init/sysinit.go
@@ -27,7 +27,7 @@ func findImages(cfg *config.CloudConfig) ([]string, error) {
 
 	dir, err := os.Open(config.IMAGES_PATH)
 	if os.IsNotExist(err) {
-		log.Debugf("Not loading images, %s does not exist")
+		log.Debugf("Not loading images, %s does not exist", config.IMAGES_PATH)
 		return result, nil
 	}
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -57,6 +57,9 @@ func main() {
 	registerCmd("/usr/sbin/wait-for-docker", wait.Main)
 
 	if !reexec.Init() {
-		log.Fatalf("Failed to find an entry point for %s", os.Args[0])
+		reexec.Register(os.Args[0], control.Main)
+		if !reexec.Init() {
+			log.Fatalf("Failed to find an entry point for %s", os.Args[0])
+		}
 	}
 }

--- a/os-config_arm.yml
+++ b/os-config_arm.yml
@@ -2,7 +2,7 @@ hostname: rancher
 rancher:
   bootstrap:
     state-script:
-      image: rancher/os-statescript:v0.4.3-dev
+      image: rancher/os-statescript:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -18,7 +18,7 @@ rancher:
       - /usr/bin/ros:/usr/bin/ros:ro
       - /usr/share/ros:/usr/share/ros:ro
     udev-bootstrap:
-      image: rancher/os-udev:v0.4.3-dev
+      image: rancher/os-udev:v0.4.3-dev_arm
       environment:
       - BOOTSTRAP=true
       labels:
@@ -34,7 +34,7 @@ rancher:
       - /lib/firmware:/lib/firmware
   autoformat:
     autoformat:
-      image: rancher/os-autoformat:v0.4.3-dev
+      image: rancher/os-autoformat:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -42,7 +42,7 @@ rancher:
       net: none
       privileged: true
     udev-autoformat:
-      image: rancher/os-udev:v0.4.3-dev
+      image: rancher/os-udev:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -71,25 +71,15 @@ rancher:
         address: 127.0.0.1/8
   repositories:
     core:
-      url: https://raw.githubusercontent.com/rancher/os-services/v0.4.3-dev
+      url: https://raw.githubusercontent.com/rancher/os-services/v0.4.3-dev_arm
   state:
     fstype: auto
     dev: LABEL=RANCHER_STATE
     oem_fstype: auto
     oem_dev: LABEL=RANCHER_OEM
   services:
-    acpid:
-      image: rancher/os-acpid:v0.4.3-dev
-      labels:
-        io.rancher.os.scope: system
-      net: host
-      uts: host
-      privileged: true
-      volumes_from:
-      - command-volumes
-      - system-volumes
     all-volumes:
-      image: rancher/os-state:v0.4.3-dev
+      image: rancher/os-state:v0.4.3-dev_arm
       labels:
         io.rancher.os.createonly: "true"
         io.rancher.os.scope: system
@@ -103,7 +93,7 @@ rancher:
       - user-volumes
       - system-volumes
     cloud-init:
-      image: rancher/os-cloudinit:v0.4.3-dev
+      image: rancher/os-cloudinit:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.reloadconfig: "true"
@@ -116,7 +106,7 @@ rancher:
       - command-volumes
       - system-volumes
     cloud-init-pre:
-      image: rancher/os-cloudinit:v0.4.3-dev
+      image: rancher/os-cloudinit:v0.4.3-dev_arm
       environment:
       - CLOUD_INIT_NETWORK=false
       labels:
@@ -131,7 +121,7 @@ rancher:
       - command-volumes
       - system-volumes
     command-volumes:
-      image: rancher/os-state:v0.4.3-dev
+      image: rancher/os-state:v0.4.3-dev_arm
       labels:
         io.rancher.os.createonly: "true"
         io.rancher.os.scope: system
@@ -155,7 +145,7 @@ rancher:
       - /usr/bin/ros:/usr/sbin/wait-for-network:ro
       - /usr/bin/ros:/usr/sbin/wait-for-docker:ro
     console:
-      image: rancher/os-console:v0.4.3-dev
+      image: rancher/os-console:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: cloud-init
@@ -171,7 +161,7 @@ rancher:
       volumes:
       - /usr/bin/iptables:/sbin/iptables:ro
     container-data-volumes:
-      image: rancher/os-state:v0.4.3-dev
+      image: rancher/os-state:v0.4.3-dev_arm
       labels:
         io.rancher.os.createonly: "true"
         io.rancher.os.scope: system
@@ -183,7 +173,7 @@ rancher:
       - /var/lib/docker:/var/lib/docker
       - /var/lib/rkt:/var/lib/rkt
     network:
-      image: rancher/os-network:v0.4.3-dev
+      image: rancher/os-network:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: cloud-init-pre
@@ -195,7 +185,7 @@ rancher:
       - command-volumes
       - system-volumes
     wait-for-network:
-      image: rancher/os-network:v0.4.3-dev
+      image: rancher/os-network:v0.4.3-dev_arm
       command: wait-for-network
       labels:
         io.rancher.os.detach: "false"
@@ -207,7 +197,7 @@ rancher:
       - command-volumes
       - system-volumes
     ntp:
-      image: rancher/os-ntp:v0.4.3-dev
+      image: rancher/os-ntp:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: cloud-init, wait-for-network
@@ -216,7 +206,7 @@ rancher:
       privileged: true
       restart: always
     preload-system-images:
-      image: rancher/os-preload:v0.4.3-dev
+      image: rancher/os-preload:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -228,7 +218,7 @@ rancher:
       - command-volumes
       - system-volumes
     preload-user-images:
-      image: rancher/os-preload:v0.4.3-dev
+      image: rancher/os-preload:v0.4.3-dev_arm
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -241,7 +231,7 @@ rancher:
       - command-volumes
       - system-volumes
     syslog:
-      image: rancher/os-syslog:v0.4.3-dev
+      image: rancher/os-syslog:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
       log_driver: json-file
@@ -252,7 +242,7 @@ rancher:
       volumes_from:
       - system-volumes
     system-volumes:
-      image: rancher/os-state:v0.4.3-dev
+      image: rancher/os-state:v0.4.3-dev_arm
       labels:
         io.rancher.os.createonly: "true"
         io.rancher.os.scope: system
@@ -276,7 +266,7 @@ rancher:
       - /var/log:/var/log
       - /var/run:/var/run
     udev-cold:
-      image: rancher/os-udev:v0.4.3-dev
+      image: rancher/os-udev:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
         io.rancher.os.before: udev
@@ -286,7 +276,7 @@ rancher:
       volumes_from:
       - system-volumes
     udev:
-      image: rancher/os-udev:v0.4.3-dev
+      image: rancher/os-udev:v0.4.3-dev_arm
       environment:
       - DAEMON=true
       labels:
@@ -299,7 +289,7 @@ rancher:
       volumes_from:
       - system-volumes
     user-volumes:
-      image: rancher/os-state:v0.4.3-dev
+      image: rancher/os-state:v0.4.3-dev_arm
       labels:
         io.rancher.os.createonly: "true"
         io.rancher.os.scope: system
@@ -311,7 +301,7 @@ rancher:
       - /home:/home
       - /opt:/opt
     docker:
-      image: rancher/os-docker:v0.4.3-dev
+      image: rancher/os-docker:v0.4.3-dev_arm
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: console
@@ -330,9 +320,9 @@ rancher:
       --fixed-cidr, 172.18.42.1/16, --restart=false, -g, /var/lib/system-docker, -G, root,
       -H, 'unix:///var/run/system-docker.sock', --userland-proxy=false]
   upgrade:
-    url: https://releases.rancher.com/os/releases.yml
+    url: https://releases.rancher.com/os/releases_arm.yml
     image: rancher/os
   docker:
     tls_args: [--tlsverify, --tlscacert=/etc/docker/tls/ca.pem, --tlscert=/etc/docker/tls/server-cert.pem, --tlskey=/etc/docker/tls/server-key.pem,
       '-H=0.0.0.0:2376']
-    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock']
+    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock', --userland-proxy=false]

--- a/releases.yml
+++ b/releases.yml
@@ -3,4 +3,5 @@ available:
   - rancher/os:v0.4.0
   - rancher/os:v0.4.1
   - rancher/os:v0.4.2
-current: rancher/os:v0.4.2
+  - rancher/os:v0.4.3
+current: rancher/os:v0.4.3

--- a/releases_arm.yml
+++ b/releases_arm.yml
@@ -1,0 +1,4 @@
+---
+available:
+  - rancher/os:v0.4.3_arm
+current: rancher/os:v0.4.3_arm

--- a/scripts/mk-images-tar.sh
+++ b/scripts/mk-images-tar.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -ex
 
+suffix=""
+[ "$ARCH" == "amd64" ] || suffix="_${ARCH}"
+
 cd $(dirname $0)/..
 . scripts/build-common
 
-ln -sf bin/rancheros ./ros
-
-for i in `./ros c images -i os-config.yml`; do
+images="$(build/host_ros c images -i os-config${suffix}.yml)"
+for i in ${images}; do
     [ "${FORCE_PULL}" != "1" ] && docker inspect $i >/dev/null 2>&1 || docker pull $i;
 done
 
-docker save `./ros c images -i os-config.yml` > ${BUILD}/images.tar
+docker save ${images} > ${BUILD}/images.tar

--- a/scripts/mk-initrd.sh
+++ b/scripts/mk-initrd.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -ex
 
+TARGET=${1}
+
+ARCH=${ARCH:-"amd64"}
+DFS_IMAGE=${DFS_IMAGE:?"DFS_IMAGE not set"}
+IS_ROOTFS=${IS_ROOTFS:-0}
+
+suffix=""
+[ "$ARCH" == "amd64" ] || suffix="_${ARCH}"
+
+DFS_ARCH_IMAGE=${DFS_IMAGE}${suffix}
+
 cd $(dirname $0)/..
 . scripts/build-common
 
@@ -8,29 +19,48 @@ INITRD_DIR=${BUILD}/initrd
 
 rm -rf ${INITRD_DIR}/{usr,init}
 mkdir -p ${INITRD_DIR}/usr/{bin,share/ros}
+mkdir -p ${INITRD_DIR}/var/lib/system-docker
 
-cp -rf ${BUILD}/kernel/lib ${INITRD_DIR}/usr
+if [ "$IS_ROOTFS" == "0" ]; then
+  cp -rf ${BUILD}/kernel/lib ${INITRD_DIR}/usr/
+fi
 cp assets/docker           ${INITRD_DIR}/usr/bin/docker
-cp ${BUILD}/images.tar     ${INITRD_DIR}/usr/share/ros
-cp os-config.yml           ${INITRD_DIR}/usr/share/ros/
-cp bin/rancheros           ${INITRD_DIR}/usr/bin/ros
+if [ "$IS_ROOTFS" == "0" ]; then
+  cp ${BUILD}/images.tar     ${INITRD_DIR}/usr/share/ros/
+fi
+cp os-config${suffix}.yml  ${INITRD_DIR}/usr/share/ros/os-config.yml
+cp bin/ros                 ${INITRD_DIR}/usr/bin/
 ln -s usr/bin/ros          ${INITRD_DIR}/init
 ln -s bin                  ${INITRD_DIR}/usr/sbin
+ln -s usr/sbin             ${INITRD_DIR}/sbin
 
-DFS=$(docker create ${DFS_IMAGE})
-trap "docker rm -fv ${DFS}" EXIT
-docker export ${DFS} | tar xvf - -C ${INITRD_DIR}  --exclude=usr/bin/dockerlaunch \
-                                                   --exclude=usr/bin/docker       \
-                                                   --exclude=usr/share/git-core   \
-                                                   --exclude=usr/bin/git          \
-                                                   --exclude=usr/bin/ssh          \
-                                                   --exclude=usr/libexec/git-core \
-                                                   usr
+DFS_ARCH=$(docker create ${DFS_ARCH_IMAGE})
+trap "docker rm -fv ${DFS_ARCH}" EXIT
 
-if [ "$DEV_BUILD" == "1" ]; then
-    COMPRESS="gzip -1"
+docker export ${DFS_ARCH} | tar xvf - -C ${INITRD_DIR} --exclude=usr/bin/dockerlaunch \
+                                                       --exclude=usr/bin/docker       \
+                                                       --exclude=usr/share/git-core   \
+                                                       --exclude=usr/bin/git          \
+                                                       --exclude=usr/bin/ssh          \
+                                                       --exclude=usr/libexec/git-core \
+                                                       usr
+
+if [ "$IS_ROOTFS" == "1" ]; then
+  DFS=$(docker run -d --privileged -v /lib/modules/$(uname -r):/lib/modules/$(uname -r) ${DFS_IMAGE})
+  trap "docker rm -fv ${DFS_ARCH} ${DFS}" EXIT
+  docker exec -i ${DFS} docker load < ${BUILD}/images.tar
+  docker stop ${DFS}
+  docker run --rm --volumes-from=${DFS} debian:jessie tar -c -C /var/lib/docker ./image | tar -x -C ${INITRD_DIR}/var/lib/system-docker
+  docker run --rm --volumes-from=${DFS} debian:jessie tar -c -C /var/lib/docker ./overlay | tar -x -C ${INITRD_DIR}/var/lib/system-docker
+
+  cd ${INITRD_DIR}
+
+  tar -czf ${TARGET} .
 else
-    COMPRESS=lzma
-fi
+  COMPRESS=lzma
+  [ "$DEV_BUILD" == "1" ] && COMPRESS="gzip -1"
 
-cd ${INITRD_DIR} && find | cpio -H newc -o | ${COMPRESS} > ${DIST}/artifacts/initrd
+  cd ${INITRD_DIR}
+
+  find | cpio -H newc -o | ${COMPRESS} > ${TARGET}
+fi

--- a/scripts/mk-ros.sh
+++ b/scripts/mk-ros.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+ros="$1"
+
+ARCH=${ARCH:?"ARCH not set"}
+VERSION=${VERSION:?"VERSION not set"}
+
+cd $(dirname $0)/..
+
+strip_bin=$(which strip)
+if [ "${ARCH}" == "arm" ]; then
+  export GOARM=6
+  export CC=/usr/bin/arm-linux-gnueabihf-gcc
+  export CGO_ENABLED=1
+  strip_bin=/usr/arm-linux-gnueabihf/bin/strip
+fi
+GOARCH=${ARCH} go build -tags netgo -installsuffix netgo -ldflags "-X github.com/rancher/os/config.VERSION=${VERSION} -linkmode external -extldflags -static" -o ${ros}
+${strip_bin} --strip-all ${ros}

--- a/scripts/run
+++ b/scripts/run
@@ -101,8 +101,8 @@ if [ "$REBUILD" == "1" ]; then
     ln -s ${INITRD_TMP} ${INITRD_CURRENT}
 
     mkdir -p ${INITRD_TMP}/usr/{bin,share/ros}
-    cp bin/rancheros ${INITRD_TMP}/usr/bin/ros
-    cp -f os-config.yml ${INITRD_TMP}/usr/share/ros
+    cp bin/ros ${INITRD_TMP}/usr/bin/
+    cp -f os-config.yml ${INITRD_TMP}/usr/share/ros/
 
     pushd ${INITRD_TMP}
     find . | cpio -H newc -o | gzip > ${INITRD_TEST}


### PR DESCRIPTION
Build for amd64, arm

ARM build: `dapper make ARCH=arm rootfs` produces ./dist/artifacts/rootfs.tgz which should be extracted into the **root** partition (formatted as ext4) of a Raspberry Pi SD card (just be sure to remove everything from that root partition before). 

Make sure you add `init=/init rw`to the kernel boot params in cmdline.txt on Raspberry Pi SD card **boot** partition (formatted as FAT). 