### PR TITLE
do not print success info when loading images error

### DIFF
--- a/init/sysinit.go
+++ b/init/sysinit.go
@@ -79,11 +79,11 @@ func loadImages(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 		err = client.LoadImage(dockerClient.LoadImageOptions{
 			InputStream: input,
 		})
-		log.Infof("Done loading images from %s", inputFileName)
-
 		if err != nil {
 			return cfg, err
 		}
+
+		log.Infof("Done loading images from %s", inputFileName)
 	}
 
 	return cfg, nil


### PR DESCRIPTION
when the client.LoadImage return an error, there should not be print
success info like the following:

    "INFO[0000] Done loading images from /usr/share/ros/images.tar"

This patch fix it by move the log.Infof() after the err check.

Signed-off-by: Wang Long <long.wanglong@huawei.com>