### PR TITLE
Fix bug in install script

### DIFF
--- a/scripts/installer/lay-down-os
+++ b/scripts/installer/lay-down-os
@@ -50,7 +50,7 @@ mount_device()
 
     mkdir -p ${BASE_DIR}
 
-    if [ "$(lsblk -o name|grep RANCHER_BOOT | wc -l)" -eq "1" ]; then
+    if [ "$(lsblk -o label|grep RANCHER_BOOT | wc -l)" -gt "0" ]; then
         label=RANCHER_BOOT
     fi
     


### PR DESCRIPTION
lsblk -o label will list the labels of the block devices. Using name only returns /dev/sda, etc.
In some cases, labels may be repeated (eg - RAID configurations).  It is safer to use greater than 0.