### PR TITLE
Clean up upgrade container

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -213,6 +213,10 @@ func startUpgradeContainer(image string, stage, force, reboot bool) error {
 			return err
 		}
 
+		if err := container.Delete(); err != nil {
+			return err
+		}
+
 		if reboot && (force || yes(in, "Continue with reboot")) {
 			log.Info("Rebooting")
 			power.Reboot()


### PR DESCRIPTION
When performing two upgrades in a row, the second upgrade fails because the container is recreated with the wrong name. This deletes the container after performing an upgrade so we don't run into this problem. The issue with container recreation might be a bug in libcompose and can be resolved separately.

Fixes #690