### PR TITLE
WIP: Multiarch build part 2. Introducing arm64 and maybe ppc64le

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,57 +1,108 @@
 FROM ubuntu:15.10
 
-RUN apt-get update && \
-    apt-get -y install locales sudo vim less curl wget git rsync build-essential syslinux isolinux xorriso \
-        libblkid-dev libmount-dev libselinux1-dev cpio genisoimage qemu-kvm python-pip ca-certificates pkg-config
+ENV CROSS_PLATFROMS \
+    arm-linux-gnueabihf \
+    aarch64-linux-gnu
 
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV PATH $PATH:/usr/local/go/bin
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
+RUN for PLATFORM in ${CROSS_PLATFROMS}; do CROSS_PACKAGES="${CROSS_PACKAGES:-} gcc-${PLATFORM} g++-${PLATFORM}"; done \
+    && apt-get update \
+    && apt-get -y install \
+        locales \
+        sudo \
+        vim \
+        less \
+        curl \
+        wget \
+        git \
+        rsync \
+        build-essential \
+        syslinux \
+        isolinux \
+        xorriso \
+        libblkid-dev \
+        libmount-dev \
+        libselinux1-dev \
+        cpio \
+        genisoimage \
+        qemu-kvm \
+        python-pip \
+        ca-certificates \
+        pkg-config \
+        ${CROSS_PACKAGES} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install tox
-RUN curl -sSL https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz | tar -xz -C /usr/local
-RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/local/bin/docker
-RUN chmod +x /usr/local/bin/docker
+# Go and docker env variables
+ENV LANG=en_US.UTF-8 \
+    GOPATH=/go \
+    GOROOT=/usr/local/go \
+    GO_VERSION=1.6 \
+    DOCKER_BUILD_VERSION=1.9.1
 
-ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_SOURCE /go/src/github.com/rancher/os
-ENV DAPPER_OUTPUT ./bin ./dist
-ENV DAPPER_RUN_ARGS --privileged
-ENV SHELL /bin/bash
+# Dapper env variables
+ENV DAPPER_DOCKER_SOCKET=true \
+    DAPPER_SOURCE=/go/src/github.com/rancher/os \
+    DAPPER_OUTPUT="./bin ./dist" \
+    DAPPER_RUN_ARGS="--privileged" \
+    SHELL=/bin/bash
 WORKDIR ${DAPPER_SOURCE}
 
+# Set the $PATH
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
+# Create $GOPATH and $GOROOT and generate locale
+RUN mkdir -p $GOPATH/src $GOPATH/bin $GOROOT && chmod -R 777 $GOPATH
+RUN locale-gen en_US.UTF-8
+
+# Install the python package tox
+RUN pip install tox
+
+# Install golang
+RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz | tar -xz -C $GOROOT --strip-components=1
+
+# Get docker
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_BUILD_VERSION} > /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+# Copy .dockerignore
 COPY .dockerignore.docker .dockerignore
 
-RUN cd /usr/local/src && \
-    for i in libselinux pcre3 util-linux; do \
-        apt-get build-dep -y $i && \
-        apt-get source -y $i \
+RUN cd /usr/local/src \
+    && apt-get update \
+    && for PACKAGE in libselinux pcre3 util-linux; do \
+        apt-get build-dep -y $PACKAGE && \
+        apt-get source -y $PACKAGE \
+    ;done \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd /usr/local/src/pcre3-* \
+    && for PLATFORM in ${CROSS_PLATFROMS}; do \
+        autoreconf \
+        && CC=${PLATFORM}-gcc CXX=${PLATFORM}-g++ ./configure --host=${PLATFORM} --prefix=/usr/${PLATFORM} \
+        && make -j$(nproc) \
+        && make install \
     ;done
 
-RUN apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-RUN cd /usr/local/src/pcre3-* && \
-    autoreconf && \
-    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ ./configure --host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf && \
-    make -j$(nproc) && \
-    make install
 
-RUN cd /usr/local/src/libselinux-* && \
-    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ make CFLAGS=-Wall && \
-    make PREFIX=/usr/arm-linux-gnueabihf DESTDIR=/usr/arm-linux-gnueabihf install
+RUN cd /usr/local/src/libselinux-* \
+    && for PLATFORM in ${CROSS_PLATFROMS}; do \
+        CC=${PLATFORM}-gcc CXX=${PLATFORM}-g++ make CFLAGS=-Wall \
+        && make PREFIX=/usr/${PLATFORM} DESTDIR=/usr/${PLATFORM} install \
+    ;done
 
-RUN cd /usr/local/src/util-linux-* && \
-    autoreconf && \
-    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ ./configure --host=arm-linux-gnueabihf --prefix=/usr/arm-linux-gnueabihf \
-        --disable-all-programs \
-        --enable-libmount \
-        --enable-libblkid \
-        --enable-libuuid \
-        --enable-mount && \
-    make -j$(nproc) && \
-    make install
+RUN cd /usr/local/src/util-linux-* \
+    && for PLATFORM in ${CROSS_PLATFROMS}; do \
+        autoreconf \
+        && CC=${PLATFORM}-gcc CXX=${PLATFORM}-g++ ./configure --host=${PLATFORM} --prefix=/usr/${PLATFORM} \
+            --disable-all-programs \
+            --enable-libmount \
+            --enable-libblkid \
+            --enable-libuuid \
+            --enable-mount \
+        && make -j$(nproc) \
+        && make install \
+    ;done
 
 CMD make all
 

--- a/build.conf.arm64
+++ b/build.conf.arm64
@@ -1,0 +1,1 @@
+DOCKER_BINARY_URL=https://github.com/rancher/docker/releases/download/v1.10.2-ros_arm64/docker-1.10.2

--- a/scripts/mk-ros.sh
+++ b/scripts/mk-ros.sh
@@ -6,14 +6,23 @@ ros="$1"
 ARCH=${ARCH:?"ARCH not set"}
 VERSION=${VERSION:?"VERSION not set"}
 
+case "$ARCH" in
+	"arm")
+		GCC_PACKAGE="arm-linux-gnueabihf";;
+	"arm64")
+		GCC_PACKAGE="aarch64-linux-gnu";;
+	"ppc64le")
+		GCC_PACKAGE="powerpc64le-linux-gnu";;
+esac
+
 cd $(dirname $0)/..
 
-strip_bin=$(which strip)
-if [ "${ARCH}" == "arm" ]; then
-  export GOARM=6
-  export CC=/usr/bin/arm-linux-gnueabihf-gcc
+STRIP_BIN=$(which strip)
+if [[ "${ARCH}" != "amd64" ]]; then
+  export GOARM=7
+  export CC=/usr/bin/${GCC_PACKAGE}-gcc
   export CGO_ENABLED=1
-  strip_bin=/usr/arm-linux-gnueabihf/bin/strip
+  STRIP_BIN=/usr/${GCC_PACKAGE}/bin/strip
 fi
 GOARCH=${ARCH} go build -tags netgo -installsuffix netgo -ldflags "-X github.com/rancher/os/config.VERSION=${VERSION} -linkmode external -extldflags -static" -o ${ros}
-${strip_bin} --strip-all ${ros}
+${STRIP_BIN} --strip-all ${ros}


### PR DESCRIPTION
Here's the first commit. Some other things have to be done though:
 - [ ] Build rancher/docker: just `make binary` on a ARM64 device
 - [ ] Build rancher/docker-from-scratch
 - [ ] Build rancher/os-images
 - [ ] Build rancher/os-base

It will be cool with native RPi 3 support :)

But we may discuss when we may use ARM 32-bit userspace.
Adding `ppc64le` support to `Dockerfile.dapper` is as easy as adding `powerpc64le-linux-gnu` to `CROSS_PLATFORMS`. However, the `util-linux` fails with error: 
```
  CC       libmount/src/libmount_la-context_mount.lo
  CC       libmount/src/libmount_la-context_umount.lo
  CC       libmount/src/libmount_la-monitor.lo
  CC       sys-utils/mount-mount.o
  CC       sys-utils/umount-umount.o
  CCLD     libblkid.la
/usr/lib/gcc-cross/powerpc64le-linux-gnu/5/../../../../powerpc64le-linux-gnu/bin/ld: ./.libs/libcommon.a(libcommon_la-at.o): Relocations in generic ELF (EM: 183)
/usr/lib/gcc-cross/powerpc64le-linux-gnu/5/../../../../powerpc64le-linux-gnu/bin/ld: ./.libs/libcommon.a(libcommon_la-at.o): Relocations in generic ELF (EM: 183)
/usr/lib/gcc-cross/powerpc64le-linux-gnu/5/../../../../powerpc64le-linux-gnu/bin/ld: ./.libs/libcommon.a(libcommon_la-at.o): Relocations in generic ELF (EM: 183)
/usr/lib/gcc-cross/powerpc64le-linux-gnu/5/../../../../powerpc64le-linux-gnu/bin/ld: ./.libs/libcommon.a(libcommon_la-at.o): Relocations in generic ELF (EM: 183)
/usr/lib/gcc-cross/powerpc64le-linux-gnu/5/../../../../powerpc64le-linux-gnu/bin/ld: ./.libs/libcommon.a(libcommon_la-at.o): Relocations in generic ELF (EM: 183)
./.libs/libcommon.a(libcommon_la-at.o): error adding symbols: File in wrong format
```

Feel free to comment.