### PR TITLE
print proper tips when running `ros` or `system-docker` without using sudo 

### DIFF
--- a/cmd/control/cli.go
+++ b/cmd/control/cli.go
@@ -3,6 +3,7 @@ package control
 import (
 	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/rancher/os/config"
 )
@@ -15,6 +16,12 @@ func Main() {
 	app.Version = config.VERSION
 	app.Author = "Rancher Labs, Inc."
 	app.EnableBashCompletion = true
+	app.Before = func(c *cli.Context) error {
+		if os.Geteuid() != 0 {
+			log.Fatalf("%s: Need to be root", os.Args[0])
+		}
+		return nil
+	}
 
 	app.Commands = []cli.Command{
 		{

--- a/cmd/systemdocker/system-docker.go
+++ b/cmd/systemdocker/system-docker.go
@@ -19,6 +19,10 @@ func Main() {
 
 	newEnv = append(newEnv, "DOCKER_HOST="+config.DOCKER_SYSTEM_HOST)
 
+	if os.Geteuid() != 0 {
+		log.Fatalf("%s: Need to be root", os.Args[0])
+	}
+
 	os.Args[0] = config.DOCKER_DIST_BIN
 	if err := syscall.Exec(os.Args[0], os.Args, newEnv); err != nil {
 		log.Fatal(err)

--- a/tests/integration/rostest/test_06_subdir.py
+++ b/tests/integration/rostest/test_06_subdir.py
@@ -14,6 +14,6 @@ def test_system_docker_survives_custom_docker_install(qemu):
     SSH(qemu).check_call('bash', '-c', '''
         set -x -e
         mkdir x
-        sudo mount $(ros dev LABEL=RANCHER_STATE) x
+        sudo mount $(sudo ros dev LABEL=RANCHER_STATE) x
         [ -d x/ros_subdir/home/rancher ]
     '''.strip())


### PR DESCRIPTION
`ros` and `system-docker` command requires user to be the root user,
when we running them without using sudo, it will print the follow:

```
[rancher@rancher ~]$ ros os list
ERRO[0000] Failed to read /var/lib/rancher/conf/cloud-config.d: open
/var/lib/rancher/conf/cloud-config.d: permission denied
ERRO[0000] Error reading config files                    err=open
/var/lib/rancher/conf/cloud-config.yml: permission denied
files=[/var/lib/rancher/conf/cloud-config.yml]
ERRO[0000] Failed [1/4] 25%
ERRO[0000] Failed to load config
......
......
FATA[0000] open /var/lib/rancher/conf/cloud-config.yml: permission
denied
```

and

```
[rancher@rancher ~]$ system-docker restart docker
Failed to kill container(docker): Cannot connect to the Docker daemon.
Is the docker daemon running on this host?
```
this patch make the tips more clear and simple.

Signed-off-by: Wang Long <long.wanglong@huawei.com>