### PR TITLE
fix gen-os-config.sh error

### DIFF
--- a/scripts/gen-os-config.sh
+++ b/scripts/gen-os-config.sh
@@ -5,6 +5,7 @@ cd $(dirname $0)/..
 
 set -a
 . build.conf
+. build.conf.${ARCH}
 
 SUFFIX=""
 [ "${ARCH}" == "amd64" ] || SUFFIX="_${ARCH}"


### PR DESCRIPTION
Need to source build.conf.${ARCH} file when we generate os-config.yml
after the pr(https://github.com/rancher/os/pull/815) merged.

this patch fix it.

Signed-off-by: Wang Long <long.wanglong@huawei.com>