### PR TITLE
Make sure /usr/bin/go from gccgo exists

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 ARG HOST_ARCH
 ENV HOST_ARCH ${HOST_ARCH}
-RUN mkdir -p /usr/local && cd /usr/local && \
+RUN ln -sf go-6 /usr/bin/go && mkdir -p /usr/local && cd /usr/local && \
     wget -O - https://storage.googleapis.com/golang/go1.6.src.tar.gz | tar -xz && \
     cd go/src && GOROOT_BOOTSTRAP=/usr GOARCH=${HOST_ARCH} GOHOSTARCH=${HOST_ARCH} ./make.bash
 


### PR DESCRIPTION
Make sure /usr/bin/go from gccgo exists

Fix dapper image build, which broke at some point: apparently because of gccgo packaging change