### PR TITLE
Fix lay-down-os shell error

### DIFF
--- a/scripts/installer/lay-down-os
+++ b/scripts/installer/lay-down-os
@@ -21,7 +21,7 @@ do
         *) exit 1 ;;
     esac
 done
-[ "$ARCH" == "arm" && "$ENV" != "rancher-upgrade" ] && ENV=arm
+[[ "$ARCH" == "arm" && "$ENV" != "rancher-upgrade" ]] && ENV=arm
 
 DIST=${DIST:-/dist}
 CLOUD_CONFIG=${CLOUD_CONFIG:-"${SCRIPTS_DIR}/conf/empty.yml"}


### PR DESCRIPTION
the current code for lay-down-os will cause the following error when
install rancheros to disk.

```
-bash: [: missing `]'
```

Signed-off-by: Wang Long <long.wanglong@huawei.com>