### PR TITLE
Only pull upgrade image if not found locally

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -199,8 +199,16 @@ func startUpgradeContainer(image string, stage, force, reboot, kexec bool) error
 		return err
 	}
 
-	if err := container.Pull(); err != nil {
+	client, err := docker.NewSystemClient()
+	if err != nil {
 		return err
+	}
+
+	// Only pull image if not found locally
+	if _, err := client.InspectImage(image); err != nil {
+		if err := container.Pull(); err != nil {
+			return err
+		}
 	}
 
 	if !stage {


### PR DESCRIPTION
This solves two problems relating to #771.

1. If a local image exists and there is a remote image with the same name, `ros os upgrade` will pull and overwrite the local image.
2. If a local image exists and there isn't a remote image with the same name, `ros os upgrade` will give an error saying that the upgrade image does not exist.