### PR TITLE
Dockerfile.dapper: make sure to update apt repos before fetching build deps and sources

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -39,6 +39,7 @@ RUN if [ "${TOOLCHAIN}" != "" ] && ! which ${TOOLCHAIN}-gcc; then \
     ;fi
 
 RUN if [ "${TOOLCHAIN}" != "" ]; then \
+        apt-get update && \
         cd /usr/local/src && \
         for i in libselinux libsepol pcre3 util-linux; do \
             apt-get build-dep -y $i && \

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -4,4 +4,4 @@ set -e
 cd $(dirname $0)/..
 . ./scripts/dapper-common
 
-exec dapper -s
+exec dapper -d -s


### PR DESCRIPTION
Dockerfile.dapper: make sure to update apt repos before fetching build deps and sources.

Also, use dapper -d flag in scripts/shell.sh for better visibility