### PR TITLE
Delete previous upgrade container before upgrading

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -212,6 +212,12 @@ func startUpgradeContainer(image string, stage, force, reboot, kexec bool) error
 			}
 		}
 
+		// If there is already an upgrade container, delete it
+		// Up() should to this, but currently does not due to a bug
+		if err := container.Delete(); err != nil {
+			return err
+		}
+
 		if err := container.Up(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Basically the same idea as #782, except now the previous upgrade container is deleted before upgrading as well. Usually the container will be removed after upgrade, but when using the `--kexec` flag the system reboots before the removal occurs.

I still suspect an issue with container recreation in libcompose to be the underlying issue, but this can be fixed at a later time.

#836 