### PR TITLE
Apply network configurations again after cloud-init

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -105,7 +105,7 @@ rancher:
         io.rancher.os.detach: "false"
         io.rancher.os.reloadconfig: "true"
         io.rancher.os.scope: system
-        io.rancher.os.after: cloud-init-pre, wait-for-network, ntp
+        io.rancher.os.after: ntp
       net: host
       uts: host
       privileged: true
@@ -180,13 +180,39 @@ rancher:
       - /var/lib/docker:/var/lib/docker
       - /var/lib/system-docker:/var/lib/system-docker
       - /var/lib/rkt:/var/lib/rkt
-    network:
+    network-pre:
       image: {{.OS_IMAGES_ROOT}}/os-network:{{.VERSION}}{{.SUFFIX}}
       labels:
         io.rancher.os.scope: system
         io.rancher.os.after: cloud-init-pre
       net: host
       uts: host
+      pid: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    network:
+      image: {{.OS_IMAGES_ROOT}}/os-network:{{.VERSION}}{{.SUFFIX}}
+      labels:
+        io.rancher.os.scope: system
+        io.rancher.os.after: cloud-init
+      environment:
+      - DAEMON=true
+      net: host
+      uts: host
+      pid: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
+    wait-for-network-pre:
+      image: {{.OS_IMAGES_ROOT}}/os-network:{{.VERSION}}{{.SUFFIX}}
+      command: wait-for-network
+      labels:
+        io.rancher.os.detach: "false"
+        io.rancher.os.scope: system
+        io.rancher.os.after: network-pre
       pid: host
       privileged: true
       volumes_from:
@@ -208,7 +234,7 @@ rancher:
       image: {{.OS_IMAGES_ROOT}}/os-ntp:{{.VERSION}}{{.SUFFIX}}
       labels:
         io.rancher.os.scope: system
-        io.rancher.os.after: wait-for-network
+        io.rancher.os.after: wait-for-network-pre
       net: host
       uts: host
       privileged: true

--- a/tests/integration/assets/test_10/cloud-config.yml
+++ b/tests/integration/assets/test_10/cloud-config.yml
@@ -1,0 +1,5 @@
+#cloud-config
+rancher:
+  cloud_init:
+    datasources:
+    - url:https://s3-us-west-2.amazonaws.com/rancher-os-test/cloud-config.yml

--- a/tests/integration/rostest/test_10_network_from_url.py
+++ b/tests/integration/rostest/test_10_network_from_url.py
@@ -1,0 +1,52 @@
+import pytest
+import rostest.util as u
+from rostest.util import SSH
+
+pytestmark = pytest.mark.skipif(u.arch != 'amd64', reason='amd64 network setup impossible to replicate for arm64')
+
+cloud_config_path = './tests/integration/assets/test_10/cloud-config.yml'
+
+net_args_arch = {'amd64': ['-net', 'nic,vlan=0,model=virtio'],
+                 'arm64': ['-device', 'virtio-net-device']}
+net_args_arch['arm'] = net_args_arch['arm64']
+net_args = net_args_arch[u.arch]
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    q = u.run_qemu(request,
+                   run_args=['--cloud-config', cloud_config_path] +
+                   net_args + net_args + net_args + net_args + net_args + net_args + net_args)
+    u.flush_out(q.stdout)
+    return q
+
+
+def test_network_conf(qemu):
+    SSH(qemu).check_call('''cat > test-merge << "SCRIPT"
+set -x -e
+
+ip link show dev br0
+ip link show dev br0.100 | grep br0.100@br0
+ip link show dev eth1.100 | grep 'master br0'
+ip link show dev eth6 | grep 'master bond0'
+ip link show dev eth7 | grep 'master bond0'
+[ "$(</sys/class/net/bond0/bonding/mode)" = "active-backup 1" ]
+
+SCRIPT
+sudo bash test-merge
+    '''.strip())
+
+
+def test_network_dns_ros_set(qemu):
+    SSH(qemu).check_call('''
+set -x -e
+
+sudo ros config set rancher.network.dns.search '[a,b]'
+if [ "$(sudo ros config get rancher.network.dns.search)" == "- a
+ - b
+
+ " ]; then
+    sudo ros config get rancher.network.dns.search
+    exit 1
+ fi
+    '''.strip())

--- a/trash.yml
+++ b/trash.yml
@@ -70,7 +70,7 @@ import:
   version: v1.10.3
 
 - package: github.com/rancher/netconf
-  version: d7d620ef4ea62a9d04b51c7b3d9dc83fe7ffaa1b
+  version: f953ace624d8bade198682d343eb7e25d9c8899c
 
 - package: github.com/ryanuber/go-glob
   version: 0067a9abd927e50aed5190662702f81231413ae0

--- a/vendor/github.com/rancher/netconf/netconf_linux.go
+++ b/vendor/github.com/rancher/netconf/netconf_linux.go
@@ -273,6 +273,10 @@ func setGateway(gateway string) error {
 
 func applyInterfaceConfig(link netlink.Link, netConf InterfaceConfig) error {
 	if netConf.Bond != "" {
+		if err := netlink.LinkSetDown(link); err != nil {
+			return err
+		}
+
 		b, err := Bond(netConf.Bond)
 		if err != nil {
 			return err


### PR DESCRIPTION
Depends on rancher/netconf#10 and rancher/os-images#73

Adds a flag `-daemon` to netconf. If true, netconf will behave as it does now and run dhcpd as a daemon. If false, netconf will exit after applying network configurations.

Adds two new system services to apply network configurations again after cloud-init. The two new services are called network and wait-for-network, and the previous network and wait-for-network services are now network-pre and wait-for-network-pre. The new services are essentially the same as the old ones, except they occur after cloud-init.

New order for services:
1. cloud-init-pre
2. network-pre
3. wait-for-network-pre
4. ntp
5. cloud-init
6. network
7. wait-for-network

#846 
#758 
#339 