### PR TITLE
fix lay-down-os error

### DIFF
--- a/scripts/installer/lay-down-os
+++ b/scripts/installer/lay-down-os
@@ -6,7 +6,7 @@ SCRIPTS_DIR=$(dirname ${0})
 . "${SCRIPTS_DIR}/build.conf"
 VERSION=${VERSION:?"VERSION not set"}
 
-while getopts "i:f:c:d:t:r:o:p:k:a" OPTION
+while getopts "i:f:c:d:t:r:o:p:ka:" OPTION
 do
     case ${OPTION} in
         i) DIST="$OPTARG" ;;


### PR DESCRIPTION
option `-k` does not need an argument and `-a` need one.

Signed-off-by: Wang Long <long.wanglong@huawei.com>