### PR TITLE
If DNS override is set, pass `--nohook resolv.conf` to dhcpd

### DIFF
--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -48,11 +48,18 @@ func Main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	hostname, _ := cloudinit.SetHostname(cfg) // ignore error
 	log.Infof("Network: hostname: '%s'", hostname)
+
+	if _, err := resolvconf.Build("/etc/resolv.conf", cfg.Rancher.Network.Dns.Nameservers, cfg.Rancher.Network.Dns.Search, nil); err != nil {
+		log.Error(err)
+	}
+
 	if err := netconf.ApplyNetworkConfigs(&cfg.Rancher.Network); err != nil {
 		log.Error(err)
 	}
+
 	hostname, _ = cloudinit.SetHostname(cfg) // ignore error
 	log.Infof("Network: hostname: '%s' (from DHCP, if not set by cloud-config)", hostname)
 	if hostname != "" {
@@ -76,12 +83,7 @@ func Main() {
 			log.Error(err)
 		}
 	}
-	if cfg.Rancher.Network.Dns.Override {
-		log.WithFields(log.Fields{"nameservers": cfg.Rancher.Network.Dns.Nameservers}).Info("Override nameservers")
-		if _, err := resolvconf.Build("/etc/resolv.conf", cfg.Rancher.Network.Dns.Nameservers, cfg.Rancher.Network.Dns.Search, nil); err != nil {
-			log.Error(err)
-		}
-	}
+
 	if f, err := os.Create(NETWORK_DONE); err != nil {
 		log.Error(err)
 	} else {

--- a/trash.yml
+++ b/trash.yml
@@ -70,7 +70,7 @@ import:
   version: v1.10.3
 
 - package: github.com/rancher/netconf
-  version: f953ace624d8bade198682d343eb7e25d9c8899c
+  version: 6cd9ea0b3a45482c9e9aee9be9ca88c96b2f71e6
 
 - package: github.com/ryanuber/go-glob
   version: 0067a9abd927e50aed5190662702f81231413ae0

--- a/vendor/github.com/rancher/netconf/netconf_linux.go
+++ b/vendor/github.com/rancher/netconf/netconf_linux.go
@@ -187,7 +187,7 @@ func ApplyNetworkConfigs(netCfg *NetworkConfig) error {
 	for iface, args := range dhcpLinks {
 		wg.Add(1)
 		go func(iface, args string) {
-			runDhcp(iface, args)
+			runDhcp(netCfg, iface, args)
 			wg.Done()
 		}(iface, args)
 	}
@@ -197,7 +197,7 @@ func ApplyNetworkConfigs(netCfg *NetworkConfig) error {
 	return err
 }
 
-func runDhcp(iface string, argstr string) {
+func runDhcp(netCfg *NetworkConfig, iface string, argstr string) {
 	log.Infof("Running DHCP on %s", iface)
 	args := []string{}
 	if argstr != "" {
@@ -209,6 +209,10 @@ func runDhcp(iface string, argstr string) {
 	}
 	if len(args) == 0 {
 		args = defaultDhcpArgs
+	}
+
+	if netCfg.Dns.Override {
+		args = append(args, "--nohook", "resolv.conf")
 	}
 
 	args = append(args, iface)


### PR DESCRIPTION
Depends on rancher/netconf#11

Currently `/etc/resolv.conf` is built after dhcpd starts and only if the override flag is given. However, since dhcpd is run as a daemon, it'll eventually write to `/etc/resolv.conf`.

This PR always builds `/etc/resolv.conf` prior to starting dhcpd. If the override flag is present, dhcpd is run with the `--nohook resolv.conf` flag, which prevents it from writing to `/etc/resolv.conf`.

#873 has some integration tests relevant to this.