### PR TITLE
Revert "Check the validity of the service name"

### DIFF
--- a/cmd/control/service.go
+++ b/cmd/control/service.go
@@ -95,7 +95,7 @@ func disable(c *cli.Context) {
 
 	for _, service := range c.Args() {
 		if _, ok := cfg.Rancher.ServicesInclude[service]; !ok {
-			logrus.Fatalf("ERROR: Service %s is not a valid service, use \"sudo ros service list\" to list the services", service)
+			continue
 		}
 
 		cfg.Rancher.ServicesInclude[service] = false
@@ -118,7 +118,7 @@ func del(c *cli.Context) {
 
 	for _, service := range c.Args() {
 		if _, ok := cfg.Rancher.ServicesInclude[service]; !ok {
-			logrus.Fatalf("ERROR: Service %s is not a valid service, use \"sudo ros service list\" to list the services", service)
+			continue
 		}
 		delete(cfg.Rancher.ServicesInclude, service)
 		changed = true
@@ -137,21 +137,12 @@ func enable(c *cli.Context) {
 		logrus.Fatal(err)
 	}
 
-	services, err := util.GetServices(cfg.Rancher.Repositories.ToArray())
-	if err != nil {
-		logrus.Fatalf("Failed to get services: %v", err)
-	}
-
 	var enabledServices []string
 
 	for _, service := range c.Args() {
 		if val, ok := cfg.Rancher.ServicesInclude[service]; !ok || !val {
 			if strings.HasPrefix(service, "/") && !strings.HasPrefix(service, "/var/lib/rancher/conf") {
 				logrus.Fatalf("ERROR: Service should be in path /var/lib/rancher/conf")
-			}
-
-			if !util.Contains(services, service) {
-				logrus.Fatalf("ERROR: Service %s is not a valid service, use \"sudo ros service list\" to list the services", service)
 			}
 
 			cfg.Rancher.ServicesInclude[service] = true


### PR DESCRIPTION
Reverts rancher/os#870

The idea behind this PR is good, but the current implementation breaks some of the functionality with [custom services](http://docs.rancher.com/os/configuration/system-services/#adding-custom-system-services). We'll try to implement this with a different approach for v0.4.5.