### PR TITLE
Remove DHCP override flag

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -90,6 +90,7 @@ type RancherConfig struct {
 	ServicesInclude     map[string]bool                   `yaml:"services_include,omitempty"`
 	Modules             []string                          `yaml:"modules,omitempty"`
 	Network             netconf.NetworkConfig             `yaml:"network,omitempty"`
+	DefaultNetwork      netconf.NetworkConfig             `yaml:"default_network,omitempty"`
 	Repositories        Repositories                      `yaml:"repositories,omitempty"`
 	Ssh                 SshConfig                         `yaml:"ssh,omitempty"`
 	State               StateConfig                       `yaml:"state,omitempty"`

--- a/init/init.go
+++ b/init/init.go
@@ -164,8 +164,8 @@ func getLaunchConfig(cfg *config.CloudConfig, dockerCfg *config.DockerConfig) (*
 
 	args := dockerlaunch.ParseConfig(&launchConfig, append(dockerCfg.Args, dockerCfg.ExtraArgs...)...)
 
-	launchConfig.DnsConfig.Nameservers = cfg.Rancher.Network.Dns.Nameservers
-	launchConfig.DnsConfig.Search = cfg.Rancher.Network.Dns.Search
+	launchConfig.DnsConfig.Nameservers = cfg.Rancher.DefaultNetwork.Dns.Nameservers
+	launchConfig.DnsConfig.Search = cfg.Rancher.DefaultNetwork.Dns.Search
 	launchConfig.Environment = dockerCfg.Environment
 	launchConfig.EmulateSystemd = true
 

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -61,7 +61,7 @@ rancher:
   cloud_init:
     datasources:
     - configdrive:/media/config-2
-  network:
+  default_network:
     dns:
       nameservers: [8.8.8.8, 8.8.4.4]
   repositories:

--- a/tests/integration/assets/test_09/cloud-config.yml
+++ b/tests/integration/assets/test_09/cloud-config.yml
@@ -22,7 +22,6 @@ rancher:
           mode: 1
         address: 123.123.123.124/32
     dns:
-      override: true
       search:
         - mydomain.com
         - example.com

--- a/trash.yml
+++ b/trash.yml
@@ -70,7 +70,7 @@ import:
   version: v1.10.3
 
 - package: github.com/rancher/netconf
-  version: 6a771a0593c146f35634c405ab9ccfec50db65e1
+  version: 7880fdeac0923a05b86a0b5774b4dc96a5749d76
 
 - package: github.com/ryanuber/go-glob
   version: 0067a9abd927e50aed5190662702f81231413ae0

--- a/vendor/github.com/rancher/netconf/types.go
+++ b/vendor/github.com/rancher/netconf/types.go
@@ -26,7 +26,6 @@ type InterfaceConfig struct {
 }
 
 type DnsConfig struct {
-	Override    bool     `yaml:"override"`
 	Nameservers []string `yaml:"nameservers,flow,omitempty"`
 	Search      []string `yaml:"search,flow,omitempty"`
 }


### PR DESCRIPTION
Depends on rancher/netconf#13

The override key is no longer necessary to apply DNS settings from cloud config. Similar to #881, this is done by adding a `default_network` key to distinguish between user set DNS settings and those in `os-config.yml`.