### PR TITLE
Add upgrade flag to upgrade persistent console

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -86,6 +86,7 @@ type RancherConfig struct {
 	Debug               bool                              `yaml:"debug,omitempty"`
 	RmUsr               bool                              `yaml:"rm_usr,omitempty"`
 	Log                 bool                              `yaml:"log,omitempty"`
+	ForceConsoleRebuild bool                              `yaml:"force_console_rebuild,omitempty"`
 	Disable             []string                          `yaml:"disable,omitempty"`
 	ServicesInclude     map[string]bool                   `yaml:"services_include,omitempty"`
 	Modules             []string                          `yaml:"modules,omitempty"`


### PR DESCRIPTION
Adds the flag `upgrade-console` to `ros os upgrade`. This will set the new config flag `force_console_rebuild`, which will force a console rebuild on next boot. After rebuilding the console, the flag is set back to false.