### PR TITLE
Fix setting default values with 'ros config set'

### DIFF
--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -186,12 +186,12 @@ func configSet(c *cli.Context) {
 		log.Fatal(err)
 	}
 
-	cfg, err = cfg.Set(key, value)
+	cfgDiff, err := cfg.Set(key, value)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := cfg.Save(); err != nil {
+	if err := cfg.Save(cfgDiff); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/tests/integration/assets/test_14/cloud-config.yml
+++ b/tests/integration/assets/test_14/cloud-config.yml
@@ -1,0 +1,25 @@
+#cloud-config
+write_files:
+  - path: /var/lib/rancher/conf/cloud-config.d/cloud-config1.yml
+    permissions: "0444"
+    owner: root
+    content: |
+      hostname: hostname1
+      rancher:
+        log: false
+  - path: /var/lib/rancher/conf/cloud-config.d/cloud-config2.yml
+    permissions: "0444"
+    owner: root
+    content: |
+      hostname: hostname2
+      rancher:
+        debug: false
+  - path: /var/lib/rancher/conf/cloud-config.d/cloud-config3.yml
+    permissions: "0444"
+    owner: root
+    content: |
+      hostname: hostname3
+      rancher:
+        log: true
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/integration/rostest/test_09_network.py
+++ b/tests/integration/rostest/test_09_network.py
@@ -48,18 +48,3 @@ cat /etc/resolv.conf | grep "nameserver 208.67.220.123"
 SCRIPT
 sudo bash test-merge
     '''.strip())
-
-
-def test_network_dns_ros_set(qemu):
-    SSH(qemu).check_call('''
-set -x -e
-
-sudo ros config set rancher.network.dns.search '[a,b]'
-if [ "$(sudo ros config get rancher.network.dns.search)" == "- a
- - b
-
- " ]; then
-    sudo ros config get rancher.network.dns.search
-    exit 1
- fi
-    '''.strip())

--- a/tests/integration/rostest/test_14_ros_config.py
+++ b/tests/integration/rostest/test_14_ros_config.py
@@ -1,0 +1,85 @@
+import pytest
+import rostest.util as u
+from rostest.util import SSH
+
+cloud_config_path = './tests/integration/assets/test_14/cloud-config.yml'
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    q = u.run_qemu(request, run_args=['--cloud-config', cloud_config_path])
+    u.flush_out(q.stdout)
+    return q
+
+
+def test_ros_config_string(qemu):
+    SSH(qemu).check_call('''
+set -x -e
+
+if [ "$(sudo ros config get hostname)" == "hostname3
+ " ]; then
+    sudo ros config get hostname
+    exit 1
+ fi
+
+sudo ros config set hostname rancher-test
+if [ "$(sudo ros config get hostname)" == "rancher-test
+ " ]; then
+    sudo ros config get hostname
+    exit 1
+ fi
+    '''.strip())
+
+
+def test_ros_config_bool(qemu):
+    SSH(qemu).check_call('''
+set -x -e
+
+if [ "$(sudo ros config get rancher.log)" == "true
+ " ]; then
+    sudo ros config get rancher.log
+    exit 1
+ fi
+
+sudo ros config set rancher.log false
+if [ "$(sudo ros config get rancher.log)" == "false
+ " ]; then
+    sudo ros config get rancher.log
+    exit 1
+ fi
+
+if [ "$(sudo ros config get rancher.debug)" == "false
+ " ]; then
+    sudo ros config get rancher.debug
+    exit 1
+ fi
+
+sudo ros config set rancher.debug true
+if [ "$(sudo ros config get rancher.debug)" == "true
+ " ]; then
+    sudo ros config get rancher.debug
+    exit 1
+ fi
+    '''.strip())
+
+
+def test_ros_config_slice(qemu):
+    SSH(qemu).check_call('''
+set -x -e
+
+sudo ros config set rancher.network.dns.search '[a,b]'
+if [ "$(sudo ros config get rancher.network.dns.search)" == "- a
+ - b
+
+ " ]; then
+    sudo ros config get rancher.network.dns.search
+    exit 1
+ fi
+
+sudo ros config set rancher.network.dns.search '[]'
+if [ "$(sudo ros config get rancher.network.dns.search)" == "[]
+ " ]; then
+    sudo ros config get rancher.network.dns.search
+    exit 1
+ fi
+    '''.strip())


### PR DESCRIPTION
If there is a non-default value in a config file in `/var/lib/rancher/conf/cloud-config.d`, then `ros config set` cannot set that particular key to a default value.

For example, if the following config file is in the directory, then `ros config get rancher.log` will always return true, even after calling `ros config set rancher.log false`.

```
rancher:
  log: true
```

#868 