### PR TITLE
Remove `-D` when we set rancher.debug=false

### DIFF
--- a/config/disk.go
+++ b/config/disk.go
@@ -61,6 +61,13 @@ func LoadConfig() (*CloudConfig, error) {
 		if !util.Contains(cfg.Rancher.SystemDocker.Args, "-D") {
 			cfg.Rancher.SystemDocker.Args = append(cfg.Rancher.SystemDocker.Args, "-D")
 		}
+	} else {
+		if util.Contains(cfg.Rancher.Docker.Args, "-D") {
+			cfg.Rancher.Docker.Args = util.FilterStrings(cfg.Rancher.Docker.Args, func(x string) bool { return x != "-D" })
+		}
+		if util.Contains(cfg.Rancher.SystemDocker.Args, "-D") {
+			cfg.Rancher.SystemDocker.Args = util.FilterStrings(cfg.Rancher.SystemDocker.Args, func(x string) bool { return x != "-D" })
+		}
 	}
 
 	return cfg, nil


### PR DESCRIPTION
when we set rancher.debug to true, the current code also set `-D` flag
to system-docker and user-docker daemon.
and then we change rancher.debug to false, the `-D` flag is also exist
by using command `sudo ros config get rancher.docker`.

this patch fix it.

Signed-off-by: Wang Long <long.wanglong@huawei.com>