### PR TITLE
Add support for booting live iso off of EFI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -169,5 +169,8 @@ ENV DAPPER_OUTPUT ./bin ./dist ./build/os-config.yml ./build/initrd
 RUN curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > /usr/bin/dapper && \
     chmod +x /usr/bin/dapper
 
+RUN mkdir -p src/docker/00-rootfs/build && \
+    curl -pfL ${!OS_BASE_URL} | tar xvJf - -C src/docker/00-rootfs/build
+
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -169,8 +169,8 @@ ENV DAPPER_OUTPUT ./bin ./dist ./build/os-config.yml ./build/initrd
 RUN curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > /usr/bin/dapper && \
     chmod +x /usr/bin/dapper
 
-RUN mkdir -p src/docker/00-rootfs/build && \
-    curl -pfL ${!OS_BASE_URL} | tar xvJf - -C src/docker/00-rootfs/build
+RUN mkdir -p images/00-rootfs/build && \
+    curl -pfL ${!OS_BASE_URL} | tar xvJf - -C images/00-rootfs/build
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -24,6 +24,7 @@ RUN apt-get update && \
         rsync \
         sudo \
         tox \
+        unzip \
         vim \
         wget \
         xorriso
@@ -163,6 +164,12 @@ RUN source /usr/src/toolchain-env; if [ "${TOOLCHAIN}" != "" ]; then \
     ;fi
 
 ENV GOARCH $ARCH
+
+# Install rEFInd for EFI boot
+ENV REFIND_VERSION=0.10.3
+RUN curl -fL  http://downloads.sourceforge.net/project/refind/${REFIND_VERSION}/refind-bin-${REFIND_VERSION}.zip > ${DOWNLOADS}/refind.zip && \
+    unzip -j -p ${DOWNLOADS}/refind.zip refind-bin-${REFIND_VERSION}/refind/refind_x64.efi > ${DOWNLOADS}/refind_x64.efi && rm -f ${DOWNLOADS}/refind.zip
+
 
 ENV DAPPER_OUTPUT ./bin ./dist ./build/os-config.yml ./build/initrd
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -10,6 +10,7 @@ RUN apt-get update && \
         gccgo \
         genisoimage \
         git \
+        grub-efi \
         isolinux \
         less \
         libblkid-dev \
@@ -164,12 +165,6 @@ RUN source /usr/src/toolchain-env; if [ "${TOOLCHAIN}" != "" ]; then \
     ;fi
 
 ENV GOARCH $ARCH
-
-# Install rEFInd for EFI boot
-ENV REFIND_VERSION=0.10.3
-RUN curl -fL  http://downloads.sourceforge.net/project/refind/${REFIND_VERSION}/refind-bin-${REFIND_VERSION}.zip > ${DOWNLOADS}/refind.zip && \
-    unzip -j -p ${DOWNLOADS}/refind.zip refind-bin-${REFIND_VERSION}/refind/refind_x64.efi > ${DOWNLOADS}/refind_x64.efi && rm -f ${DOWNLOADS}/refind.zip
-
 
 ENV DAPPER_OUTPUT ./bin ./dist ./build/os-config.yml ./build/initrd
 

--- a/efi.txt
+++ b/efi.txt
@@ -1,0 +1,27 @@
+To install with EFI:
+
+A: get the refind binaries
+
+# If you want to do it directly
+mkdir -p refind
+REFIND_VERSION=0.10.3
+wget http://downloads.sourceforge.net/project/refind/${REFIND_VERSION}/refind-bin-${REFIND_VERSION}.zip refind/refind.zip
+unzip -j refind/refind.zip refind-bin-${REFIND_VERSION}/refind/refind_x64.efi -d refind
+
+# if you want to install directly via apt:
+apt-add-repository ppa:rodsmith/refind
+apt-get update
+apt-get install refind
+
+
+B: Add to the installation process in scripts/package-iso
+
+2. Make the default boot directory: mkdir -p ${CD}/EFI/BOOT
+3. Copy the refind file over: cp refind/refind_x64.efi ${CD}/EFI/BOOT/BOOTX64.EFI
+4. Copy the base refind.conf: cp scripts/refind.conf ${CD}/EFI/BOOT/refind.conf
+5. Add the following xorriso options
+
+    -eltorito-alt-boot -e EFI/BOOT/BOOTX64.EFI -no-emul-boot \
+
+This installation includes *no* additional icons or drivers. It is just meant to get RancherOS booted on an EFI system.
+If you want to add support for graphical installations, additional filesystems, and everything else.... you will need a lot more 

--- a/efi.txt
+++ b/efi.txt
@@ -1,24 +1,20 @@
 To install with EFI:
 
-A: get the refind binaries
+A: install grub-efi
 
-# If you want to do it directly
-mkdir -p refind
-REFIND_VERSION=0.10.3
-wget http://downloads.sourceforge.net/project/refind/${REFIND_VERSION}/refind-bin-${REFIND_VERSION}.zip refind/refind.zip
-unzip -j refind/refind.zip refind-bin-${REFIND_VERSION}/refind/refind_x64.efi -d refind
-
-# if you want to install directly via apt:
-apt-add-repository ppa:rodsmith/refind
-apt-get update
-apt-get install refind
-
+apt install grub-efi
 
 B: Add to the installation process in scripts/package-iso
 
-2. Make the default boot directory: mkdir -p ${CD}/EFI/BOOT
-3. Copy the refind file over: cp refind/refind_x64.efi ${CD}/EFI/BOOT/BOOTX64.EFI
-4. Copy the base refind.conf: cp scripts/refind.conf ${CD}/EFI/BOOT/refind.conf
+1. Make directories ${CD}/boot/grub and ${CD}/EFI/BOOT
+2. Install the various grub modules from /usr/lib/grub/x86_64-efi/ to ${CD}/boot/grub/x86_64-efi/
+3. Copy scripts/grub.cfg to ${CD}/boot/grub/grub.cfg
+4. Run grub-mkimage to create the grub image: 
+
+(cd ${CD} && grub-mkimage  -O x86_64-efi -o EFI/BOOT/BOOTX64.EFI --config=boot/grub/grub.cfg --compression=auto --prefix='()/boot/grub' disk part_msdos fat iso9660 )
+
+NOTE: do *NOT* try to install the linux module directly in the grub image; it causes command-line options not to be passed and is a known bug.
+
 5. Add the following xorriso options
 
     -eltorito-alt-boot -e EFI/BOOT/BOOTX64.EFI -no-emul-boot \
@@ -26,3 +22,7 @@ B: Add to the installation process in scripts/package-iso
 
 This installation includes *no* additional icons or drivers. It is just meant to get RancherOS booted on an EFI system.
 If you want to add support for graphical installations, additional filesystems, and everything else.... you will need a lot more 
+
+
+
+

--- a/scripts/grub.cfg
+++ b/scripts/grub.cfg
@@ -1,0 +1,14 @@
+set default="0"
+set timeout=10
+
+set gfxmode=auto
+insmod efi_gop
+insmod efi_uga
+
+
+menuentry "Rancher" {
+        set gfxpayload=keep
+        linux   /boot/vmlinuz  quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
+        initrd  /boot/initrd
+}
+

--- a/scripts/package-iso
+++ b/scripts/package-iso
@@ -7,10 +7,8 @@ cd $(dirname $0)/..
 ARTIFACTS=$(pwd)/dist/artifacts
 CD=${BUILD}/cd
 
-# for traditional boot
+## TRADITIONAL MBR BOOT
 mkdir -p ${CD}/boot/isolinux
-# for EFI boot
-mkdir -p ${CD}/EFI/BOOT
 
 cp ${ARTIFACTS}/initrd                        ${CD}/boot
 cp ${ARTIFACTS}/vmlinuz                       ${CD}/boot
@@ -18,16 +16,39 @@ cp scripts/isolinux.cfg                       ${CD}/boot/isolinux
 cp /usr/lib/ISOLINUX/isolinux.bin             ${CD}/boot/isolinux
 cp /usr/lib/syslinux/modules/bios/ldlinux.c32 ${CD}/boot/isolinux
 
-# for rEFInd EFI boot
-cp scripts/refind.conf                        ${CD}/EFI/BOOT
-cp ${DOWNLOADS}/refind_x64.efi                ${CD}/EFI/BOOT/BOOTX64.EFI
+
+## EFI BOOT
+mkdir -p ${CD}/EFI/BOOT
+mkdir -p ${CD}/boot/grub
+cp scripts/grub.cfg ${CD}/boot/grub
+cp -r /usr/lib/grub/x86_64-efi/ ${CD}/boot/grub
+
+(cd ${CD} && grub-mkimage  -O x86_64-efi -o EFI/BOOT/BOOTX64.EFI --config=boot/grub/grub.cfg --compression=auto --prefix='()/boot/grub' disk part_msdos fat iso9660 )
+
+# make the EFI FAT filesystem to boot
+EFIIMG=boot/efiboot.img
+CDEFI=${CD}/${EFIIMG}
+rm -f ${CDEFI}
+dd if=/dev/zero of=${CDEFI} bs=4k count=1000
+mkfs.vfat ${CDEFI}
+mkdir -p tmp/
+mount -o loop ${CDEFI} tmp/
+cp -r ${CD}/EFI tmp/
+umount tmp/
+rmdir tmp/
+
+rm -rf ${CD}/EFI
+
+
+## BUILD THE ISO IMAGE
 
 cd ${CD} && xorriso \
     -as mkisofs \
     -l -J -R -V "${DISTRIB_ID}" \
     -no-emul-boot -boot-load-size 4 -boot-info-table \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
-    -eltorito-alt-boot -e EFI/BOOT/BOOTX64.EFI -no-emul-boot \
     -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
+    -eltorito-alt-boot \
+    -e ${EFIIMG} -no-emul-boot \
     -isohybrid-gpt-basdat \
     -o ${ARTIFACTS}/$(echo ${DISTRIB_ID} | tr '[:upper:]' '[:lower:]').iso ${CD}

--- a/scripts/package-iso
+++ b/scripts/package-iso
@@ -7,18 +7,26 @@ cd $(dirname $0)/..
 ARTIFACTS=$(pwd)/dist/artifacts
 CD=${BUILD}/cd
 
+# for traditional boot
 mkdir -p ${CD}/boot/isolinux
-mkdir -p ${CD}/boot/isolinux
+# for EFI boot¬
+mkdir -p ${CD}/EFI/BOOT¬
 
 cp ${ARTIFACTS}/initrd                        ${CD}/boot
 cp ${ARTIFACTS}/vmlinuz                       ${CD}/boot
 cp scripts/isolinux.cfg                       ${CD}/boot/isolinux
 cp /usr/lib/ISOLINUX/isolinux.bin             ${CD}/boot/isolinux
 cp /usr/lib/syslinux/modules/bios/ldlinux.c32 ${CD}/boot/isolinux
+
+# for rEFInd EFI boot
+cp scripts/refind.conf                        ${CD}/EFI/BOOT¬
+cp refind/refind_x64.efi                      ${CD}/EFI/BOOT/BOOTX64.EFI
+
 cd ${CD} && xorriso \
     -as mkisofs \
     -l -J -R -V "${DISTRIB_ID}" \
     -no-emul-boot -boot-load-size 4 -boot-info-table \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
+    -eltorito-alt-boot -e EFI/boot/bootx64.efi -no-emul-boot \¬
     -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
     -o ${ARTIFACTS}/$(echo ${DISTRIB_ID} | tr '[:upper:]' '[:lower:]').iso ${CD}

--- a/scripts/package-iso
+++ b/scripts/package-iso
@@ -9,8 +9,8 @@ CD=${BUILD}/cd
 
 # for traditional boot
 mkdir -p ${CD}/boot/isolinux
-# for EFI boot¬
-mkdir -p ${CD}/EFI/BOOT¬
+# for EFI boot
+mkdir -p ${CD}/EFI/BOOT
 
 cp ${ARTIFACTS}/initrd                        ${CD}/boot
 cp ${ARTIFACTS}/vmlinuz                       ${CD}/boot
@@ -19,14 +19,14 @@ cp /usr/lib/ISOLINUX/isolinux.bin             ${CD}/boot/isolinux
 cp /usr/lib/syslinux/modules/bios/ldlinux.c32 ${CD}/boot/isolinux
 
 # for rEFInd EFI boot
-cp scripts/refind.conf                        ${CD}/EFI/BOOT¬
-cp refind/refind_x64.efi                      ${CD}/EFI/BOOT/BOOTX64.EFI
+cp scripts/refind.conf                        ${CD}/EFI/BOOT
+cp ${DOWNLOADS}/refind_x64.efi                ${CD}/EFI/BOOT/BOOTX64.EFI
 
 cd ${CD} && xorriso \
     -as mkisofs \
     -l -J -R -V "${DISTRIB_ID}" \
     -no-emul-boot -boot-load-size 4 -boot-info-table \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
-    -eltorito-alt-boot -e EFI/boot/bootx64.efi -no-emul-boot \¬
+    -eltorito-alt-boot -e EFI/BOOT/BOOTX64.EFI -no-emul-boot \
     -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
     -o ${ARTIFACTS}/$(echo ${DISTRIB_ID} | tr '[:upper:]' '[:lower:]').iso ${CD}

--- a/scripts/refind.conf
+++ b/scripts/refind.conf
@@ -1,0 +1,8 @@
+timeout -1
+hideui all
+scanfor manual
+menuentry Rancher {
+  loader /boot/vmlinuz
+  initrd /boot/initrd
+  options "quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]"
+}

--- a/scripts/refind.conf
+++ b/scripts/refind.conf
@@ -1,9 +1,0 @@
-timeout -1
-hideui all
-scanfor manual
-default_selection Rancher
-menuentry Rancher {
-  loader /boot/vmlinuz
-  initrd /boot/initrd
-  options "quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]"
-}

--- a/scripts/refind.conf
+++ b/scripts/refind.conf
@@ -1,6 +1,7 @@
 timeout -1
 hideui all
 scanfor manual
+default_selection Rancher
 menuentry Rancher {
   loader /boot/vmlinuz
   initrd /boot/initrd


### PR DESCRIPTION
Uses Rod Smith's rEFIt boot manager and enables ability to boot live iso on system with UEFI/EFI firmware without legacy support mode (CSM).

This PR is as requested by @ibuildthecloud see #844.

Several points:

1. To test, launch in virtual box, under Settings -> System, check "EFI"
2. Once launched, log in as usual (rancher/rancher), and see that the directory `/sys/firmware/efi/` exists. This only is created by the Linux kernel when the system was booted EFI.
3. This does not install EFI-bootable when installed to local disk `ros install`. Once this PR is accepted and merged, I will look at adding that capability. 

