### PR TITLE
Support registry credentials in cloud config

### DIFF
--- a/config/disk.go
+++ b/config/disk.go
@@ -11,6 +11,7 @@ import (
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/coreos/coreos-cloudinit/datasource"
 	"github.com/coreos/coreos-cloudinit/initialize"
+	"github.com/docker/engine-api/types"
 	composeConfig "github.com/docker/libcompose/config"
 	"github.com/rancher/os/util"
 )
@@ -193,6 +194,9 @@ func amendNils(c *CloudConfig) *CloudConfig {
 	}
 	if t.Rancher.ServicesInclude == nil {
 		t.Rancher.ServicesInclude = map[string]bool{}
+	}
+	if t.Rancher.RegistryAuths == nil {
+		t.Rancher.RegistryAuths = map[string]types.AuthConfig{}
 	}
 	return &t
 }

--- a/config/types.go
+++ b/config/types.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 
 	"github.com/coreos/coreos-cloudinit/config"
+	"github.com/docker/engine-api/types"
 	composeConfig "github.com/docker/libcompose/config"
 	"github.com/rancher/netconf"
 )
@@ -104,6 +105,7 @@ type RancherConfig struct {
 	SystemDocker        DockerConfig                              `yaml:"system_docker,omitempty"`
 	Upgrade             UpgradeConfig                             `yaml:"upgrade,omitempty"`
 	Docker              DockerConfig                              `yaml:"docker,omitempty"`
+	RegistryAuths       map[string]types.AuthConfig               `yaml:"registry_auths,omitempty"`
 	Defaults            Defaults                                  `yaml:"defaults,omitempty"`
 }
 

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -1,0 +1,82 @@
+package docker
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/registry"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/libcompose/docker"
+	"github.com/rancher/os/config"
+)
+
+// ConfigAuthLookup will lookup registry auth info from cloud config
+// if a context is set, it will also lookup auth info from the Docker config file
+type ConfigAuthLookup struct {
+	cfg                    *config.CloudConfig
+	context                *docker.Context
+	dockerConfigAuthLookup *docker.ConfigAuthLookup
+}
+
+func NewConfigAuthLookup(cfg *config.CloudConfig) *ConfigAuthLookup {
+	return &ConfigAuthLookup{
+		cfg: cfg,
+	}
+}
+
+func populateRemaining(authConfig *types.AuthConfig) error {
+	if authConfig.Auth == "" {
+		return nil
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(authConfig.Auth)
+	if err != nil {
+		return err
+	}
+
+	decodedSplit := strings.Split(string(decoded), ":")
+	if len(decodedSplit) != 2 {
+		return fmt.Errorf("Invalid auth: %s", authConfig.Auth)
+	}
+
+	authConfig.Username = decodedSplit[0]
+	authConfig.Password = decodedSplit[1]
+
+	return nil
+}
+
+func (c *ConfigAuthLookup) SetConfig(cfg *config.CloudConfig) {
+	c.cfg = cfg
+}
+
+func (c *ConfigAuthLookup) SetContext(context *docker.Context) {
+	c.context = context
+	c.dockerConfigAuthLookup = docker.NewConfigAuthLookup(context)
+}
+
+func (c *ConfigAuthLookup) Lookup(repoInfo *registry.RepositoryInfo) types.AuthConfig {
+	if repoInfo == nil || repoInfo.Index == nil {
+		return types.AuthConfig{}
+	}
+	authConfig := registry.ResolveAuthConfig(c.All(), repoInfo.Index)
+
+	err := populateRemaining(&authConfig)
+	if err != nil {
+		log.Error(err)
+		return types.AuthConfig{}
+	}
+
+	return authConfig
+}
+
+func (c *ConfigAuthLookup) All() map[string]types.AuthConfig {
+	registryAuths := c.cfg.Rancher.RegistryAuths
+	if c.dockerConfigAuthLookup != nil {
+		for registry, authConfig := range c.dockerConfigAuthLookup.All() {
+			registryAuths[registry] = authConfig
+		}
+	}
+	return registryAuths
+}


### PR DESCRIPTION
Example cloud config:

```
#cloud-config
rancher:
  registry_auths:
    "https://index.docker.io/v1/":
      auth: asdfasdf
```

#775 