### PR TITLE
Enable more dots in RancherOS docker host names (for Amazon EC2)

### DIFF
--- a/cmd/userdocker/main.go
+++ b/cmd/userdocker/main.go
@@ -81,7 +81,11 @@ func startDocker(cfg *config.CloudConfig) error {
 
 	if dockerCfg.TLS {
 		log.Debug("Generating TLS certs if needed")
-		if err := control.Generate(true, "/etc/docker/tls", []string{"127.0.0.1", "*", "*.*", "*.*.*", "*.*.*.*"}); err != nil {
+		if err := control.Generate(
+			true,
+			"/etc/docker/tls",
+			[]string{"127.0.0.1", "*", "*.*", "*.*.*", "*.*.*.*", "*.*.*.*.*", "*.*.*.*.*.*", "*.*.*.*.*.*.*"},
+		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Enable more dots in RancherOS docker host names (for Amazon EC2)