### PR TITLE
Preserve `/usr/local` across reboots

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -336,6 +336,7 @@ rancher:
       volumes:
       - /home:/home
       - /opt:/opt
+      - /usr/local:/usr/local
     docker:
       image: {{.OS_REPO}}/os-docker:{{.VERSION}}{{.SUFFIX}}
       labels:


### PR DESCRIPTION
Preserve `/usr/local` across reboots.

Makes it easier to customize docker (by dropping custom docker binaries into `/usr/local/bin`) without forcing to switch to a persistent console.