### PR TITLE
Add missing commits from os-images

### DIFF
--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -1,7 +1,7 @@
 FROM rancher/os-centosconsole-base
 # FROM amd64=centos:7 arm64=skip arm=armhfbuild/centos:7
 RUN yum upgrade -y && \
-    yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
+    yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 RUN ln -s /sbin/agetty /sbin/getty

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -1,7 +1,7 @@
 FROM rancher/os-fedoraconsole-base
 # FROM amd64=fedora:23 arm64=rancher/aarch64-fedora:23 arm=armv7/armhf-fedora:23
 RUN dnf upgrade -y && \
-    dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
+    dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 RUN ln -s /sbin/agetty /sbin/getty


### PR DESCRIPTION
Images were moved back into this repo, but there have been some commits to `os-images` since then.

https://github.com/rancher/os-images/commit/73ecdd7627b633070999f8c70c18bd12514ada18
https://github.com/rancher/os-images/commit/86af2c443a082e551f3dc6fc1f2862a249fcd20e
https://github.com/rancher/os-images/commit/a269ae31443803db1390ca0a4a4c6ba6e7bf4666
https://github.com/rancher/os-images/commit/4f348b23437c2eb925bb84d42f3bca65d687ba13