### PR TITLE
Remove unneeded service processing code

### DIFF
--- a/compose/project.go
+++ b/compose/project.go
@@ -225,7 +225,7 @@ func newCoreServiceProject(cfg *config.CloudConfig, useNetwork bool) (*project.P
 				log.Errorf("Failed to parse YAML configuration: %s : %v", service, err)
 				continue
 			}
-			bytes, err = yaml.Marshal(adjustContainerNames(config.StringifyValues(m)))
+			bytes, err = yaml.Marshal(adjustContainerNames(m))
 			if err != nil {
 				log.Errorf("Failed to marshal YAML configuration: %s : %v", service, err)
 				continue
@@ -276,7 +276,7 @@ func StageServices(cfg *config.CloudConfig, services ...string) error {
 			return fmt.Errorf("Failed to parse YAML configuration: %s : %v", service, err)
 		}
 
-		bytes, err = yaml.Marshal(config.StringifyValues(m))
+		bytes, err = yaml.Marshal(m)
 		if err != nil {
 			return fmt.Errorf("Failed to marshal YAML configuration: %s : %v", service, err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1,75 +1,9 @@
 package config
 
 import (
-	"fmt"
-
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/rancher/os/util"
 )
-
-var keysToStringify = []string{
-	"command",
-	"dns",
-	"dns_search",
-	"entrypoint",
-	"env_file",
-	"environment",
-	"labels",
-	"links",
-}
-
-func isPathToStringify(path []interface{}) bool {
-	l := len(path)
-	if l == 0 {
-		return false
-	}
-	if sk, ok := path[l-1].(string); ok {
-		return util.Contains(keysToStringify, sk)
-	}
-	return false
-}
-
-func stringifyValue(data interface{}, path []interface{}) interface{} {
-	switch data := data.(type) {
-	case map[interface{}]interface{}:
-		result := make(map[interface{}]interface{}, len(data))
-		if isPathToStringify(path) {
-			for k, v := range data {
-				switch v := v.(type) {
-				case []interface{}:
-					result[k] = stringifyValue(v, append(path, k))
-				case map[interface{}]interface{}:
-					result[k] = stringifyValue(v, append(path, k))
-				default:
-					result[k] = fmt.Sprint(v)
-				}
-			}
-		} else {
-			for k, v := range data {
-				result[k] = stringifyValue(v, append(path, k))
-			}
-		}
-		return result
-	case []interface{}:
-		result := make([]interface{}, len(data))
-		if isPathToStringify(path) {
-			for k, v := range data {
-				result[k] = fmt.Sprint(v)
-			}
-		} else {
-			for k, v := range data {
-				result[k] = stringifyValue(v, append(path, k))
-			}
-		}
-		return result
-	default:
-		return data
-	}
-}
-
-func StringifyValues(data map[interface{}]interface{}) map[interface{}]interface{} {
-	return stringifyValue(data, nil).(map[interface{}]interface{})
-}
 
 func Merge(bytes []byte) error {
 	data, err := readConfig(bytes, false)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -53,53 +53,6 @@ func TestFilterKey(t *testing.T) {
 	assert.Equal(expectedRest, rest)
 }
 
-func TestStringifyValues(t *testing.T) {
-	assert := require.New(t)
-	data := map[interface{}]interface{}{
-		"ssh_authorized_keys": []string{"pubk1", "pubk2"},
-		"hostname":            "ros-test",
-		"rancher": map[interface{}]interface{}{
-			"services": map[interface{}]interface{}{
-				"my-service": map[interface{}]interface{}{
-					"command": []interface{}{"echo", 1, false, "nothing"},
-					"labels": map[interface{}]interface{}{
-						"some-bool": true,
-						"some-num":  42,
-					},
-					"dsa-pub": "dsa-test2",
-				},
-			},
-			"docker": map[interface{}]interface{}{
-				"ca_key":  "ca_key-test3",
-				"ca_cert": "ca_cert-test4",
-				"args":    []string{"args_test5"},
-			},
-		},
-	}
-	expected := map[interface{}]interface{}{
-		"ssh_authorized_keys": []string{"pubk1", "pubk2"},
-		"hostname":            "ros-test",
-		"rancher": map[interface{}]interface{}{
-			"services": map[interface{}]interface{}{
-				"my-service": map[interface{}]interface{}{
-					"command": []interface{}{"echo", "1", "false", "nothing"},
-					"labels": map[interface{}]interface{}{
-						"some-bool": "true",
-						"some-num":  "42",
-					},
-					"dsa-pub": "dsa-test2",
-				},
-			},
-			"docker": map[interface{}]interface{}{
-				"ca_key":  "ca_key-test3",
-				"ca_cert": "ca_cert-test4",
-				"args":    []string{"args_test5"},
-			},
-		},
-	}
-	assert.Equal(expected, StringifyValues(data))
-}
-
 func TestUnmarshalOrReturnString(t *testing.T) {
 	assert := require.New(t)
 

--- a/tests/integration/assets/test_19/cloud-config.yml
+++ b/tests/integration/assets/test_19/cloud-config.yml
@@ -1,0 +1,6 @@
+#cloud-config
+rancher:
+  services_include:
+    https://gist.githubusercontent.com/joshwget/a8dd813f35cee3cf562de4454217a533/raw/5a991bb8c37bf2a1a405f5a898231d925a78ad3d/gistfile1.txt: true
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/integration/rostest/test_19_lenient_service_parsing.py
+++ b/tests/integration/rostest/test_19_lenient_service_parsing.py
@@ -1,0 +1,18 @@
+import time
+import pytest
+import rostest.util as u
+from rostest.util import SSH
+
+cloud_config_path = './tests/integration/assets/test_19/cloud-config.yml'
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    q = u.run_qemu(request, run_args=['--cloud-config', cloud_config_path])
+    u.flush_out(q.stdout)
+    return q
+
+
+def test_lenient_service_parsing(qemu):
+    time.sleep(5)
+    SSH(qemu).check_call("sudo system-docker ps -a | grep test-parsing")


### PR DESCRIPTION
Removes some old code that was necessary with an earlier version of libcompose. Adds a test to ensure that unquoted booleans and numbers are still allowed in `environment` and `labels` fields.