### PR TITLE
LUKS/cryptsetup, BTRFS, LVM2, mdadm, iSCSI, NFS for real use cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ else
 	touch $@
 endif
 
+assets/extra.tar.gz:
+ifdef EXTRA_MODULES_URL
+	mkdir -p $(dir $@)
+	curl -L "$(EXTRA_MODULES_URL)" > $@
+endif
+
 ifdef COMPILED_KERNEL_URL
 
 installer: minimal
@@ -54,7 +60,7 @@ build/kernel/:
 	wget -O - "$(COMPILED_KERNEL_URL)" | tar -xzf - -C $@
 
 
-dist/artifacts/initrd: bin/ros assets/docker assets/selinux/policy.29 build/kernel/ build/images.tar assets/modules.tar.gz
+dist/artifacts/initrd: bin/ros assets/docker assets/selinux/policy.29 build/kernel/ build/images.tar assets/modules.tar.gz assets/extra.tar.gz
 	mkdir -p $(dir $@)
 	HOST_SUFFIX=$(HOST_SUFFIX) SUFFIX=$(SUFFIX) DFS_IMAGE=$(DFS_IMAGE) DEV_BUILD=$(DEV_BUILD) \
 	       KERNEL_RELEASE=$(KERNEL_RELEASE) ARCH=$(ARCH) ./scripts/mk-initrd.sh $@

--- a/build.conf
+++ b/build.conf
@@ -1,8 +1,8 @@
-IMAGE_NAME=rancher/os
-VERSION=v0.4.4-dev
+IMAGE_NAME=tetatetit/os
+VERSION=v0.4.5
 DFS_IMAGE=rancher/docker:v1.10.3
 SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.2/policy.29
 
 HOSTNAME_DEFAULT=rancher
-OS_IMAGES_ROOT=rancher
+OS_IMAGES_ROOT=tetatetit
 OS_SERVICES_REPO=https://raw.githubusercontent.com/rancher/os-services

--- a/build.conf.amd64
+++ b/build.conf.amd64
@@ -5,4 +5,4 @@ COMPILED_KERNEL_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubu
 DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 OS_RELEASES_YML=https://releases.rancher.com/os/releases.yml
 VBOX_MODULES_URL=https://github.com/tetatetit/os-vbox/releases/download/Ubuntu-4.4.0-23.41-rancher/vbox-modules.tar.gz
-#EXTRA_MODULES_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubuntu-4.4.0-23.41-rancher-kvm/extra.tar.gz
+EXTRA_MODULES_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubuntu-4.4.0-23.41-rancher-kvm/extra.tar.gz

--- a/build.conf.amd64
+++ b/build.conf.amd64
@@ -4,4 +4,4 @@ TOOLCHAIN= #empty
 COMPILED_KERNEL_URL=https://github.com/rancher/os-kernel/releases/download/Ubuntu-4.2.0-34.39-rancher/linux-4.2.8-ckt4-rancher-x86.tar.gz
 DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 OS_RELEASES_YML=https://releases.rancher.com/os/releases.yml
-VBOX_MODULES_URL=https://github.com/rancher/os-vbox/releases/download/v0.0.2/vbox-modules.tar.gz
+VBOX_MODULES_URL=https://github.com/tetatetit/os-vbox/releases/download/Ubuntu-4.2.0-30.36-rancher/vbox-modules.tar.gz

--- a/build.conf.amd64
+++ b/build.conf.amd64
@@ -1,7 +1,7 @@
 DAPPER_BASE=ubuntu:16.04
 TOOLCHAIN= #empty
 
-COMPILED_KERNEL_URL=https://github.com/rancher/os-kernel/releases/download/Ubuntu-4.2.0-34.39-rancher/linux-4.2.8-ckt4-rancher-x86.tar.gz
+COMPILED_KERNEL_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubuntu-4.4.0-23.41-rancher-kvm/linux-4.4.10-rancher-x86.tar.gz
 DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 OS_RELEASES_YML=https://releases.rancher.com/os/releases.yml
-VBOX_MODULES_URL=https://github.com/tetatetit/os-vbox/releases/download/Ubuntu-4.2.0-30.36-rancher/vbox-modules.tar.gz
+VBOX_MODULES_URL=https://github.com/tetatetit/os-vbox/releases/download/Ubuntu-4.4.0-23.41-rancher/vbox-modules.tar.gz

--- a/build.conf.amd64
+++ b/build.conf.amd64
@@ -5,3 +5,4 @@ COMPILED_KERNEL_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubu
 DOCKER_BINARY_URL=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 OS_RELEASES_YML=https://releases.rancher.com/os/releases.yml
 VBOX_MODULES_URL=https://github.com/tetatetit/os-vbox/releases/download/Ubuntu-4.4.0-23.41-rancher/vbox-modules.tar.gz
+#EXTRA_MODULES_URL=https://github.com/tetatetit/os-kernel/releases/download/Ubuntu-4.4.0-23.41-rancher-kvm/extra.tar.gz

--- a/config/data_funcs.go
+++ b/config/data_funcs.go
@@ -3,7 +3,7 @@ package config
 import (
 	log "github.com/Sirupsen/logrus"
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
-
+	shellwords "github.com/mattn/go-shellwords"
 	"github.com/rancher/os/util"
 	"strings"
 )
@@ -154,10 +154,19 @@ func unmarshalOrReturnString(value string) (result interface{}) {
 
 func parseCmdline(cmdLine string) map[interface{}]interface{} {
 	result := make(map[interface{}]interface{})
+	params, err := shellwords.Parse(cmdLine)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "cmdline": cmdLine}).Error("Failed to parse kernel params")
+		return result
+	}
 
 outer:
-	for _, part := range strings.Split(cmdLine, " ") {
-		if !strings.HasPrefix(part, "rancher.") {
+	for _, part := range params {
+		if true &&
+			!strings.HasPrefix(part, "rancher.") &&
+			!strings.HasPrefix(part, "ssh_authorized_keys=") &&
+			!strings.HasPrefix(part, "hostname=") &&
+			!strings.HasPrefix(part, "default_hostname=") {
 			continue
 		}
 

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -363,4 +363,4 @@ rancher:
   docker:
     tls_args: [--tlsverify, --tlscacert=/etc/docker/tls/ca.pem, --tlscert=/etc/docker/tls/server-cert.pem, --tlskey=/etc/docker/tls/server-key.pem,
       '-H=0.0.0.0:2376']
-    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock']
+    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -G, docker, -H, 'unix:///var/run/docker.sock']

--- a/scripts/mk-initrd.sh
+++ b/scripts/mk-initrd.sh
@@ -42,6 +42,12 @@ if [ "$ARCH" == "amd64" ]; then
   depmod -a -b ${INITRD_DIR}/usr $KERNEL_RELEASE
 fi
 
+if [ -e assets/extra.tar.gz ]; then
+  KERNEL_RELEASE=$(tar xvf assets/extra.tar.gz -C ${INITRD_DIR}/usr | cut -f4 -d/ | cut -f1 -d ' ')
+  rm -rf ${INITRD_DIR}/usr/lib/firmware/.git
+  depmod -a -b ${INITRD_DIR}/usr $KERNEL_RELEASE
+fi
+
 DFS_ARCH=$(docker create ${DFS_IMAGE}${SUFFIX})
 trap "docker rm -fv ${DFS_ARCH}" EXIT
 


### PR DESCRIPTION
Also:
- Switched 4.4 kernel which has essentially newer BTRFS version as result more thorough and reliable
- Added EXTRA_MODULES_URL build var allowing to build with extra kernel modules needed to boot on some bare metal (real case with my server, that's why added :-) )
- Allowing BTRFS for docker unsticking it from overlay driver by default (prevented it to start from mounted BTRFS as /var/lib/docker without changing config manually)
-  Added ssh_authorized_keys='["ssh_rsa fookey1== foo@bar.com", "ssh_rsa fookey2== foo@bar.com]' kernel param support mapped to ros/cloud-init scheme appropritely, as well as all other with spaces (single- or double-quoted like shell args), except write_file but it can be enabled too if makes sence.
- Temporary switched to repo path to my forked till my os-base LUKS, BTRFS and other storage related chages are not merged to original.