### PR TITLE
add tmp to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ tests/integration/.tox
 .trash-cache
 .dapper
 vendor/*/*/*/.git
+tmp


### PR DESCRIPTION
add tmp to .dockerignore

let's please add tmp to .dockerignore: it's in .gitignore and I've got a boatload of stuff there, for my local testing