### PR TITLE
Console switch changes

### DIFF
--- a/cmd/control/console.go
+++ b/cmd/control/console.go
@@ -24,6 +24,12 @@ func consoleSubcommands() []cli.Command {
 			Name:   "switch",
 			Usage:  "switch currently running console",
 			Action: consoleSwitch,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "force, f",
+					Usage: "do not prompt for input",
+				},
+			},
 		},
 		{
 			Name:   "list",
@@ -39,10 +45,12 @@ func consoleSwitch(c *cli.Context) error {
 	}
 	newConsole := c.Args()[0]
 
-	in := bufio.NewReader(os.Stdin)
-	question := fmt.Sprintf("Switching consoles will destroy the current console container and restart Docker. Continue")
-	if !yes(in, question) {
-		return nil
+	if !c.Bool("force") {
+		in := bufio.NewReader(os.Stdin)
+		question := fmt.Sprintf("Switching consoles will destroy the current console container and restart Docker. Continue")
+		if !yes(in, question) {
+			return nil
+		}
 	}
 
 	cfg := config.LoadConfig()

--- a/cmd/control/console.go
+++ b/cmd/control/console.go
@@ -47,8 +47,9 @@ func consoleSwitch(c *cli.Context) error {
 
 	if !c.Bool("force") {
 		in := bufio.NewReader(os.Stdin)
-		question := fmt.Sprintf("Switching consoles will destroy the current console container and restart Docker. Continue")
-		if !yes(in, question) {
+		fmt.Println("Switching consoles will destroy the current console container and restart Docker.")
+		fmt.Println("Note: You will also be logged out.")
+		if !yes(in, "Continue") {
 			return nil
 		}
 	}

--- a/cmd/control/service.go
+++ b/cmd/control/service.go
@@ -19,7 +19,7 @@ type projectFactory struct {
 
 func (p *projectFactory) Create(c *cli.Context) (project.APIProject, error) {
 	cfg := config.LoadConfig()
-	return compose.GetProject(cfg, true)
+	return compose.GetProject(cfg, true, false)
 }
 
 func beforeApp(c *cli.Context) error {

--- a/cmd/switchconsole/switch_console.go
+++ b/cmd/switchconsole/switch_console.go
@@ -18,13 +18,15 @@ func Main() {
 
 	cfg := config.LoadConfig()
 
-	project, err := compose.GetProject(cfg, true)
+	project, err := compose.GetProject(cfg, true, false)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err = compose.LoadService(project, cfg, true, newConsole); err != nil {
-		log.Fatal(err)
+	if newConsole != "default" {
+		if err = compose.LoadService(project, cfg, true, newConsole); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if err = project.Up(context.Background(), options.Up{

--- a/cmd/userdocker/main.go
+++ b/cmd/userdocker/main.go
@@ -102,7 +102,7 @@ func startDocker(cfg *config.CloudConfig) (string, types.HijackedResponse, error
 
 	log.Infof("Starting Docker in context: %s", storageContext)
 
-	p, err := compose.GetProject(cfg, true)
+	p, err := compose.GetProject(cfg, true, false)
 	if err != nil {
 		return "", types.HijackedResponse{}, err
 	}

--- a/compose/project.go
+++ b/compose/project.go
@@ -56,8 +56,8 @@ func RunServiceSet(name string, cfg *config.CloudConfig, configs map[string]*com
 	})
 }
 
-func GetProject(cfg *config.CloudConfig, networkingAvailable bool) (*project.Project, error) {
-	return newCoreServiceProject(cfg, networkingAvailable)
+func GetProject(cfg *config.CloudConfig, networkingAvailable, loadConsole bool) (*project.Project, error) {
+	return newCoreServiceProject(cfg, networkingAvailable, loadConsole)
 }
 
 func newProject(name string, cfg *config.CloudConfig, environmentLookup composeConfig.EnvironmentLookup, authLookup *rosDocker.ConfigAuthLookup) (*project.Project, error) {
@@ -184,7 +184,7 @@ func adjustContainerNames(m map[interface{}]interface{}) map[interface{}]interfa
 	return m
 }
 
-func newCoreServiceProject(cfg *config.CloudConfig, useNetwork bool) (*project.Project, error) {
+func newCoreServiceProject(cfg *config.CloudConfig, useNetwork, loadConsole bool) (*project.Project, error) {
 	environmentLookup := rosDocker.NewConfigEnvironment(cfg)
 	authLookup := rosDocker.NewConfigAuthLookup(cfg)
 
@@ -197,7 +197,7 @@ func newCoreServiceProject(cfg *config.CloudConfig, useNetwork bool) (*project.P
 	p.AddListener(project.NewDefaultListener(p))
 	p.AddListener(projectEvents)
 
-	p.ReloadCallback = projectReload(p, &useNetwork, environmentLookup, authLookup)
+	p.ReloadCallback = projectReload(p, &useNetwork, loadConsole, environmentLookup, authLookup)
 
 	go func() {
 		for event := range projectEvents {

--- a/compose/reload.go
+++ b/compose/reload.go
@@ -36,7 +36,7 @@ func LoadService(p *project.Project, cfg *config.CloudConfig, useNetwork bool, s
 	return nil
 }
 
-func projectReload(p *project.Project, useNetwork *bool, environmentLookup *docker.ConfigEnvironment, authLookup *docker.ConfigAuthLookup) func() error {
+func projectReload(p *project.Project, useNetwork *bool, loadConsole bool, environmentLookup *docker.ConfigEnvironment, authLookup *docker.ConfigAuthLookup) func() error {
 	enabled := map[interface{}]interface{}{}
 	return func() error {
 		cfg := config.LoadConfig()
@@ -61,11 +61,12 @@ func projectReload(p *project.Project, useNetwork *bool, environmentLookup *dock
 			enabled[service] = service
 		}
 
-		if cfg.Rancher.Console != "" {
-			err := LoadService(p, cfg, *useNetwork, cfg.Rancher.Console)
-			if err != nil && err != network.ErrNoNetwork {
-				log.Error(err)
-			}
+		if !loadConsole || cfg.Rancher.Console == "" || cfg.Rancher.Console == "default" {
+			return nil
+		}
+
+		if err := LoadService(p, cfg, *useNetwork, cfg.Rancher.Console); err != nil && err != network.ErrNoNetwork {
+			log.Error(err)
 		}
 
 		return nil

--- a/config/types.go
+++ b/config/types.go
@@ -31,6 +31,7 @@ const (
 	DETACH        = "io.rancher.os.detach"
 	CREATE_ONLY   = "io.rancher.os.createonly"
 	RELOAD_CONFIG = "io.rancher.os.reloadconfig"
+	CONSOLE       = "io.rancher.os.console"
 	SCOPE         = "io.rancher.os.scope"
 	REBUILD       = "io.docker.compose.rebuild"
 	SYSTEM        = "system"

--- a/init/sysinit.go
+++ b/init/sysinit.go
@@ -94,7 +94,7 @@ func SysInit() error {
 	_, err := config.ChainCfgFuncs(cfg,
 		loadImages,
 		func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
-			p, err := compose.GetProject(cfg, false)
+			p, err := compose.GetProject(cfg, false, true)
 			if err != nil {
 				return cfg, err
 			}

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -161,6 +161,7 @@ rancher:
         io.rancher.os.scope: system
         io.rancher.os.after: network
         io.docker.compose.rebuild: always
+        io.rancher.os.console: default
       net: host
       uts: host
       pid: host

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -62,6 +62,7 @@ rancher:
   bootstrap_docker:
     args: [daemon, -s, overlay, -b, none, --restart=false, -g, /var/lib/system-docker,
         -G, root, -H, 'unix:///var/run/system-docker.sock', --userland-proxy=false]
+  console: default
   cloud_init:
     datasources:
     - configdrive:/media/config-2


### PR DESCRIPTION
Depends on rancher/os-services#27

Fixes the remaining gaps in functionality with console switching.

- `--force` flag to switch consoles non-interactively
- Better warning message
- Console rebuilding is consistent with how it's been in prior versions
- Able to switch to and from the default console
- `ros console enable` command that works like `ros service enable`