### PR TITLE
Support legacy Docker Compose labels

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -1,6 +1,8 @@
 package docker
 
 import (
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	dockerclient "github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
@@ -145,7 +147,9 @@ func (s *Service) Up(ctx context.Context, options options.Up) error {
 				return err
 			}
 		}
-		s.rename(ctx)
+		if err = s.rename(ctx); err != nil {
+			return err
+		}
 	}
 	if labels[config.CREATE_ONLY] == "true" {
 		return s.checkReload(labels)
@@ -181,7 +185,7 @@ func (s *Service) getContainer(ctx context.Context) (dockerclient.APIClient, typ
 	}
 
 	if len(containers) == 0 {
-		return nil, types.ContainerJSON{}, nil
+		return nil, types.ContainerJSON{}, fmt.Errorf("No containers found for %s", s.Name())
 	}
 
 	id, err := containers[0].ID()

--- a/trash.conf
+++ b/trash.conf
@@ -15,7 +15,7 @@ github.com/docker/docker 8ba9ee769ba6c451e1d2abf05368580323201667 https://github
 github.com/docker/engine-api v0.3.3
 github.com/docker/go-connections v0.2.0
 github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
-github.com/docker/libcompose 8cfb76082bb536e8e76bd51de9db8cdda2c27601 https://github.com/rancher/libcompose.git
+github.com/docker/libcompose e9127328a2aa01c6229952f5721b54a854726e0d https://github.com/rancher/libcompose.git
 github.com/docker/libnetwork v0.5.6
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/docker/machine 4a8e93ac9bc2ced1c3bc4a43c03fdaa1c2749205

--- a/vendor/github.com/docker/libcompose/docker/container.go
+++ b/vendor/github.com/docker/libcompose/docker/container.go
@@ -134,6 +134,11 @@ func (c *Container) Recreate(ctx context.Context, imageName string) (*types.Cont
 	}
 
 	hash := container.Config.Labels[labels.HASH.Str()]
+	legacyHash := container.Config.Labels[labels.HASH_LEGACY.Str()]
+
+	if hash == "" && legacyHash != "" {
+		hash = legacyHash
+	}
 	if hash == "" {
 		return nil, fmt.Errorf("Failed to find hash on old container: %s", container.Name)
 	}

--- a/vendor/github.com/docker/libcompose/docker/name.go
+++ b/vendor/github.com/docker/libcompose/docker/name.go
@@ -63,7 +63,12 @@ func NewNamer(ctx context.Context, client client.APIClient, project, service str
 
 	maxNumber := 0
 	for _, container := range containers {
-		number, err := strconv.Atoi(container.Labels[labels.NUMBER.Str()])
+		numberLabel := container.Labels[labels.NUMBER.Str()]
+		if numberLabel == "" {
+			namer.currentNumber = 1
+			return namer, nil
+		}
+		number, err := strconv.Atoi(numberLabel)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/docker/libcompose/labels/labels.go
+++ b/vendor/github.com/docker/libcompose/labels/labels.go
@@ -18,6 +18,10 @@ const (
 	SERVICE = Label("com.docker.compose.service")
 	HASH    = Label("com.docker.compose.config-hash")
 	VERSION = Label("com.docker.compose.version")
+
+	PROJECT_LEGACY = Label("io.docker.compose.project")
+	SERVICE_LEGACY = Label("io.docker.compose.service")
+	HASH_LEGACY    = Label("io.docker.compose.config-hash")
 )
 
 // EqString returns a label json string representation with the specified value.


### PR DESCRIPTION
Depends on rancher/libcompose#11

Older versions of libcompose use `io.docker.compose`, whereas new versions use `com.docker.compose`. Add support back for the old labels so upgrades from older versions aren't broken.