### PR TITLE
Additional mounts can be set in cloud config

### DIFF
--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
+	"github.com/docker/docker/pkg/mount"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/coreos-cloudinit/config"
@@ -213,6 +214,15 @@ func executeCloudConfig() error {
 			os.Create(resizeStamp)
 		} else {
 			log.Errorf("Failed to resize %s: %s", cc.Rancher.ResizeDevice, err)
+		}
+	}
+
+	for _, configMount := range cc.Mounts {
+		if len(configMount) != 4 {
+			log.Errorf("Unable to mount %s: must specify exactly four arguments", configMount[1])
+		}
+		if err := mount.Mount(configMount[0], configMount[1], configMount[2], configMount[3]); err != nil {
+			log.Errorf("Unable to mount %s: %s", configMount[1], err)
 		}
 	}
 

--- a/config/types.go
+++ b/config/types.go
@@ -81,8 +81,8 @@ type CloudConfig struct {
 	SSHAuthorizedKeys []string      `yaml:"ssh_authorized_keys"`
 	WriteFiles        []config.File `yaml:"write_files"`
 	Hostname          string        `yaml:"hostname"`
-
-	Rancher RancherConfig `yaml:"rancher,omitempty"`
+	Mounts            [][]string    `yaml:"mounts,omitempty"`
+	Rancher           RancherConfig `yaml:"rancher,omitempty"`
 }
 
 type RancherConfig struct {

--- a/tests/integration/assets/test_16/cloud-config.yml
+++ b/tests/integration/assets/test_16/cloud-config.yml
@@ -1,0 +1,9 @@
+#cloud-config
+write_files:
+- path: /test
+  content: test
+- path: /home/rancher/test
+mounts:
+- ["/test", "/home/rancher/test", "", "bind"]
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/integration/rostest/test_16_cloud_config_mounts.py
+++ b/tests/integration/rostest/test_16_cloud_config_mounts.py
@@ -1,0 +1,17 @@
+import pytest
+import rostest.util as u
+from rostest.util import SSH
+
+
+cloud_config_path = './tests/integration/assets/test_16/cloud-config.yml'
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    q = u.run_qemu(request, run_args=['--cloud-config', cloud_config_path])
+    u.flush_out(q.stdout)
+    return q
+
+
+def test_cloud_config_mounts(qemu):
+    SSH(qemu).check_call('cat /home/rancher/test | grep test')


### PR DESCRIPTION
Switched #923 to use the standard `mounts` key. Still no `swap` key support, but this can be added later.