### PR TITLE
Build script updates

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -209,8 +209,8 @@ RUN source /usr/src/toolchain-env; if [ "${TOOLCHAIN}" != "" ]; then \
         make install \
     ;fi
 
-RUN mkdir -p images/00-rootfs/build && \
-    curl -pfL ${!OS_BASE_URL} | tar xvJf - -C images/00-rootfs/build
+RUN cd ${DOWNLOADS} && \
+    curl -pfL ${!OS_BASE_URL} | tar xvJf -
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/images/00-rootfs/prebuild.sh
+++ b/images/00-rootfs/prebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TAR=${DOWNLOADS}/rootfs.tar
+
+if [ -e $TAR ]; then
+    cd $(dirname $0)
+    mkdir -p build
+    cp $TAR build
+fi

--- a/scripts/dev
+++ b/scripts/dev
@@ -6,4 +6,4 @@ cd $(dirname $0)
 
 ./build
 ./prepare
-INSTALLER=0 COMPRESS="gzip -1" ROOTFS=0 ./package
+INSTALLER=0 ROOTFS=0 ./package

--- a/scripts/package-initrd
+++ b/scripts/package-initrd
@@ -11,7 +11,7 @@ INITRD=${ARTIFACTS}/initrd
 mkdir -p ${ARTIFACTS}
 
 if [ "$COMPRESS" == "" ]; then
-    COMPRESS=lzma
+    COMPRESS="gzip -1"
 fi
 
 cd ${INITRD_DIR}

--- a/scripts/release
+++ b/scripts/release
@@ -3,5 +3,6 @@ set -e
 
 source $(dirname $0)/version
 export REPO_VERSION=$VERSION
+export COMPRESS=lzma
 
 exec $(dirname $0)/ci


### PR DESCRIPTION
Always compress with gzip unless we are doing a release.  Also download
rootfs.tar to ${DOWNLOAD} so `dapper -m bind` works better.