### PR TITLE
Remove second exec start in User Docker

### DIFF
--- a/cmd/userdocker/main.go
+++ b/cmd/userdocker/main.go
@@ -162,12 +162,6 @@ func startDocker(cfg *config.CloudConfig) (string, types.HijackedResponse, error
 		return "", types.HijackedResponse{}, err
 	}
 
-	if err := client.ContainerExecStart(context.Background(), resp.ID, types.ExecStartCheck{
-		Detach: false,
-	}); err != nil {
-		return "", types.HijackedResponse{}, err
-	}
-
 	return resp.ID, attachResp, nil
 }
 


### PR DESCRIPTION
`ContainerExecAttach` will already start the command, so there's no need for the following `ContainerExecStart` call.