### PR TITLE
Add sysctl support in cloud config

### DIFF
--- a/cmd/cloudinit/cloudinit.go
+++ b/cmd/cloudinit/cloudinit.go
@@ -19,8 +19,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -224,6 +226,15 @@ func executeCloudConfig() error {
 		device := util.ResolveDevice(configMount[0])
 		if err := mount.Mount(device, configMount[1], configMount[2], configMount[3]); err != nil {
 			log.Errorf("Unable to mount %s: %s", configMount[1], err)
+		}
+	}
+
+	for k, v := range cc.Rancher.Sysctl {
+		elems := []string{"/proc", "sys"}
+		elems = append(elems, strings.Split(k, ".")...)
+		path := path.Join(elems...)
+		if err := ioutil.WriteFile(path, []byte(v), 0644); err != nil {
+			log.Errorf("Failed to set sysctl key %s: %s", k, err)
 		}
 	}
 

--- a/config/disk.go
+++ b/config/disk.go
@@ -206,6 +206,9 @@ func amendNils(c *CloudConfig) *CloudConfig {
 	if t.Rancher.RegistryAuths == nil {
 		t.Rancher.RegistryAuths = map[string]types.AuthConfig{}
 	}
+	if t.Rancher.Sysctl == nil {
+		t.Rancher.Sysctl = map[string]string{}
+	}
 	return &t
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -112,6 +112,7 @@ type RancherConfig struct {
 	RegistryAuths       map[string]types.AuthConfig               `yaml:"registry_auths,omitempty"`
 	Defaults            Defaults                                  `yaml:"defaults,omitempty"`
 	ResizeDevice        string                                    `yaml:"resize_device,omitempty"`
+	Sysctl              map[string]string                         `yaml:"sysctl,omitempty"`
 }
 
 type UpgradeConfig struct {

--- a/tests/integration/assets/test_20/cloud-config.yml
+++ b/tests/integration/assets/test_20/cloud-config.yml
@@ -1,0 +1,7 @@
+#cloud-config
+rancher:
+  sysctl:
+    kernel.domainname: test
+    dev.cdrom.debug: 1
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/integration/rostest/test_20_sysctl.py
+++ b/tests/integration/rostest/test_20_sysctl.py
@@ -1,0 +1,17 @@
+import pytest
+import rostest.util as u
+from rostest.util import SSH
+
+cloud_config_path = './tests/integration/assets/test_20/cloud-config.yml'
+
+
+@pytest.fixture(scope="module")
+def qemu(request):
+    q = u.run_qemu(request, run_args=['--cloud-config', cloud_config_path])
+    u.flush_out(q.stdout)
+    return q
+
+
+def test_sysctl(qemu):
+    SSH(qemu).check_call("sudo cat /proc/sys/kernel/domainname | grep test")
+    SSH(qemu).check_call("sudo cat /proc/sys/dev/cdrom/debug | grep 1")


### PR DESCRIPTION
Half of the solution to #908. These settings are still applied during console start, which is too late for some purposes. The remaining half is to refactor the `cloud-init` command to allow different pieces to be applied at different times.