### PR TITLE
Go DNS patch based on build tag

### DIFF
--- a/scripts/build-target
+++ b/scripts/build-target
@@ -16,5 +16,5 @@ OUTPUT=${OUTPUT:-bin/ros}
 echo Building $OUTPUT
 
 CONST="-X github.com/docker/docker/dockerversion.GitCommit=${COMMIT} -X github.com/docker/docker/dockerversion.Version=${DOCKER_PATCH_VERSION} -X github.com/docker/docker/dockerversion.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X github.com/docker/docker/dockerversion.IAmStatic=true -X github.com/rancher/os/config.VERSION=${VERSION}"
-go build -tags "selinux cgo daemon netgo" -installsuffix netgo -ldflags "$CONST -linkmode external -extldflags -static" -o ${OUTPUT}
+go build -tags "selinux cgo daemon netgo dnspatch" -installsuffix netgo -ldflags "$CONST -linkmode external -extldflags -static" -o ${OUTPUT}
 strip --strip-all ${OUTPUT}

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -87,7 +86,7 @@ func loadFromNetwork(location string) ([]byte, error) {
 
 	var err error
 	for i := 0; i < 300; i++ {
-		net.UpdateDnsConf()
+		updateDNSCache()
 
 		var resp *http.Response
 		resp, err = http.Get(location)

--- a/util/network/update_dns_cache.go
+++ b/util/network/update_dns_cache.go
@@ -1,0 +1,9 @@
+// +build dnspatch
+
+package network
+
+import "net"
+
+func updateDNSCache() {
+	net.UpdateDnsConf()
+}

--- a/util/network/update_dns_cache_patched.go
+++ b/util/network/update_dns_cache_patched.go
@@ -1,0 +1,5 @@
+// +build !dnspatch
+
+package network
+
+func updateDNSCache() {}


### PR DESCRIPTION
No more `go build` errors outside of containerized build.