### PR TITLE
Unescape kernel params

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,7 @@ func TestParseCmdline(t *testing.T) {
 			"key1":     "value1",
 			"key2":     "value2",
 			"keyArray": []interface{}{int64(1), int64(2)},
+			"strArray": []interface{}{"url:http://192.168.1.100/cloud-config"},
 			"obj1": map[interface{}]interface{}{
 				"key3": "3value",
 				"obj2": map[interface{}]interface{}{
@@ -120,7 +121,7 @@ func TestParseCmdline(t *testing.T) {
 		},
 	}
 
-	actual := parseCmdline("a b rancher.rescue rancher.keyArray=[1,2] rancher.key1=value1 c rancher.key2=value2 rancher.obj1.key3=3value rancher.obj1.obj2.key4 rancher.key5=5 rancher.key6=a,b rancher.key7=a\nb")
+	actual := parseCmdline("a b rancher.rescue rancher.keyArray=[1,2] rancher.strArray=[\"url:http://192.168.1.100/cloud-config\"] rancher.key1=value1 c rancher.key2=value2 rancher.obj1.key3=3value rancher.obj1.obj2.key4 rancher.key5=5 rancher.key6=a,b rancher.key7=a\nb")
 
 	assert.Equal(expected, actual)
 }

--- a/config/disk.go
+++ b/config/disk.go
@@ -176,7 +176,7 @@ func readCmdline() map[interface{}]interface{} {
 
 	log.Debugf("Config cmdline %s", cmdLine)
 
-	cmdLineObj := parseCmdline(strings.TrimSpace(string(cmdLine)))
+	cmdLineObj := parseCmdline(strings.TrimSpace(util.UnescapeKernelParams(string(cmdLine))))
 
 	return cmdLineObj
 }

--- a/util/util.go
+++ b/util/util.go
@@ -225,3 +225,9 @@ func GetCurrentContainerId() (string, error) {
 
 	return parts[len(parts)-1:][0], nil
 }
+
+func UnescapeKernelParams(s string) string {
+	s = strings.Replace(s, `\"`, `"`, -1)
+	s = strings.Replace(s, `\'`, `'`, -1)
+	return s
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -90,3 +90,13 @@ func TestMerge(t *testing.T) {
 	}
 	assert.Equal(expected, Merge(m0, m1))
 }
+
+func TestCmdLineStr(t *testing.T) {
+	assert := require.New(t)
+
+	cmdLine := `rancher.cloud_init.datasources=[\'url:http://192.168.1.100/cloud-config\']`
+	assert.Equal("rancher.cloud_init.datasources=['url:http://192.168.1.100/cloud-config']", UnescapeKernelParams(cmdLine))
+
+	cmdLine = `rancher.cloud_init.datasources=[\"url:http://192.168.1.100/cloud-config\"]`
+	assert.Equal(`rancher.cloud_init.datasources=["url:http://192.168.1.100/cloud-config"]`, UnescapeKernelParams(cmdLine))
+}


### PR DESCRIPTION
Unescape kernel params

so kernel params like rancher.cloud_init.datasources='["url:http://10.0.2.2:8800/cc.yml"]' could be used

#1088