### PR TITLE
Add rsyslog configuration to system-volumes.

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -285,6 +285,8 @@ rancher:
       - /etc/hosts:/etc/hosts
       - /etc/resolv.conf:/etc/resolv.conf
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher
+      - /etc/rsyslog.conf:/etc/rsyslog.conf
+      - /etc/rsyslog.d:/etc/rsyslog.d
       - /etc/selinux:/etc/selinux
       - /lib/firmware:/lib/firmware
       - /lib/modules:/lib/modules


### PR DESCRIPTION
This change enables a user to inject rsyslog config via cloud-config. Added these two bind-mount volumes to make the ROS rsyslog config accessible to the syslog system service.

  - /etc/rsyslog.conf:/etc/rsyslog.conf
  - /etc/rsyslog.d:/etc/rsyslog.d