### PR TITLE
Refactor state

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -149,6 +149,7 @@ type StateConfig struct {
 	Directory  string   `yaml:"directory,omitempty"`
 	FsType     string   `yaml:"fstype,omitempty"`
 	Dev        string   `yaml:"dev,omitempty"`
+	Wait       bool     `yaml:"wait,omitempty"`
 	Required   bool     `yaml:"required,omitempty"`
 	Autoformat []string `yaml:"autoformat,omitempty"`
 	FormatZero bool     `yaml:"formatzero,omitempty"`

--- a/images/02-autoformat/auto-format.sh
+++ b/images/02-autoformat/auto-format.sh
@@ -12,7 +12,7 @@ for dev in ${DEVS[@]}; do
 
         # Test for our magic string (it means that the disk was made by ./boot2docker init)
         HEADER=`dd if=${dev} bs=1 count=${#MAGIC} 2>/dev/null`
-    
+
         if [ "$HEADER" = "$MAGIC" ]; then
             # save the preload userdata.tar file
             dd if=${dev} of=/userdata.tar bs=1 count=8192
@@ -23,10 +23,10 @@ for dev in ${DEVS[@]}; do
             # do not auto-format if the disk does not begin with 1MB filled with 00
             continue
         fi
-    
-        mkfs.ext4 -L RANCHER_STATE ${dev}
-    
+
+
         if [ -e "/userdata.tar" ]; then
+            mkfs.ext4 -L B2D_STATE ${dev}
             mkdir -p /mnt/new-root
             mount -t ext4 ${dev} /mnt/new-root
             pushd /mnt/new-root
@@ -49,7 +49,7 @@ rancher:
 
 ssh_authorized_keys:
  - ${AUTHORIZED_KEY1}
- - ${AUTHORIZED_KEY2} 
+ - ${AUTHORIZED_KEY2}
 
 users:
  - name: docker
@@ -59,6 +59,8 @@ users:
 EOF
             popd
             umount /mnt/new-root
+        else
+            mkfs.ext4 -L RANCHER_STATE ${dev}
         fi
 
         # do not check another device

--- a/images/02-udev/udev.sh
+++ b/images/02-udev/udev.sh
@@ -8,11 +8,26 @@ udevd --daemon
 udevadm trigger --action=add
 udevadm settle
 
-if [ "$BOOTSTRAP" = true ]; then
-    # This was needed to get USB devices to fully register
-    # There is probably a better way to do this
-    killall udevd
-    udevd --daemon
-    udevadm trigger --action=add
-    udevadm settle
+dev=$(ros config get rancher.state.dev)
+wait=$(ros config get rancher.state.wait)
+if [ "$BOOTSTRAP" != true ] || [ "$dev" == "" ] || [ "$wait" != "true" ]; then
+    exit
 fi
+
+for i in `seq 1 30`; do
+    drive=$(ros dev $dev)
+    if [ "$drive" != "" ]; then
+        break
+    fi
+    sleep 1
+done
+drive=$(ros dev $dev)
+if [ "$drive" = "" ]; then
+    exit
+fi
+for i in `seq 1 30`; do
+    if [ -e $drive ]; then
+        break
+    fi
+    sleep 1
+done

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -39,6 +39,7 @@ rancher:
       - /dev:/host/dev
       - /lib/modules:/lib/modules
       - /lib/firmware:/lib/firmware
+      - /usr/bin/ros:/usr/bin/ros:ro
   autoformat:
     autoformat:
       image: {{.OS_REPO}}/os-autoformat:{{.VERSION}}{{.SUFFIX}}
@@ -74,7 +75,6 @@ rancher:
       url: {{.OS_SERVICES_REPO}}/{{.REPO_VERSION}}
   state:
     fstype: auto
-    dev: LABEL=RANCHER_STATE
     oem_fstype: auto
     oem_dev: LABEL=RANCHER_OEM
   services:

--- a/scripts/installer/lay-down-os
+++ b/scripts/installer/lay-down-os
@@ -85,7 +85,7 @@ set timeout="1"
 
 menuentry "RancherOS-current" {
   set root=(hd0,msdos1)
-  linux /boot/vmlinuz-${VERSION}-rancheros ${append_line} console=${CONSOLE}
+  linux /boot/vmlinuz-${VERSION}-rancheros ${append_line} rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait console=${CONSOLE}
   initrd /boot/initrd-${VERSION}-rancheros
 }
 
@@ -96,7 +96,7 @@ if [ ! -z ${ROLLBACK_VERSION} ]; then
 cat >>${grub_cfg} <<EOF
 menuentry "RancherOS-rollback" {
   set root=(hd0,msdos1)
-  linux /boot/vmlinuz-${ROLLBACK_VERSION}-rancheros ${append_line} console=${CONSOLE}
+  linux /boot/vmlinuz-${ROLLBACK_VERSION}-rancheros ${append_line} rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait console=${CONSOLE}
   initrd /boot/initrd-${ROLLBACK_VERSION}-rancheros
 }
 EOF
@@ -123,7 +123,7 @@ hiddenmenu
 
 title RancherOS ${VERSION}-(current)
 root (hd0)
-kernel /boot/vmlinuz-${VERSION}-rancheros ${append_line} console=${CONSOLE}
+kernel /boot/vmlinuz-${VERSION}-rancheros ${append_line} rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait console=${CONSOLE}
 initrd /boot/initrd-${VERSION}-rancheros
 
 EOF
@@ -133,7 +133,7 @@ if [ ! -z ${ROLLBACK_VERSION} ]; then
 cat >> ${grub_file}<<EOF
 title RancherOS ${ROLLBACK_VERSION}-(rollback)
 root (hd0)
-kernel /boot/vmlinuz-${ROLLBACK_VERSION}-rancheros ${append_line} console=${CONSOLE}
+kernel /boot/vmlinuz-${ROLLBACK_VERSION}-rancheros ${append_line} rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait console=${CONSOLE}
 initrd /boot/initrd-${ROLLBACK_VERSION}-rancheros
 EOF
 fi

--- a/scripts/isolinux.cfg
+++ b/scripts/isolinux.cfg
@@ -2,4 +2,4 @@ default rancheros
 label rancheros
     kernel /boot/vmlinuz
     initrd /boot/initrd
-    append quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
+    append quiet rancher.password=rancher

--- a/scripts/run
+++ b/scripts/run
@@ -122,7 +122,7 @@ fi
 
 KERNEL_ARGS="quiet rancher.password=rancher console=${TTYCONS} ${QEMU_APPEND}"
 if [ "$FORMAT" == "1" ]; then
-    KERNEL_ARGS="${KERNEL_ARGS} rancher.state.formatzero=true rancher.state.autoformat=[/dev/sda,/dev/vda]"
+    KERNEL_ARGS="${KERNEL_ARGS} rancher.state.dev=LABEL=RANCHER_STATE rancher.state.formatzero=true rancher.state.autoformat=[/dev/sda,/dev/vda]"
 fi
 if [ "$RM_USR" == "1" ]; then
     KERNEL_ARGS="${KERNEL_ARGS} rancher.rm_usr"

--- a/tests/assets/test_01/cloud-config.yml
+++ b/tests/assets/test_01/cloud-config.yml
@@ -3,8 +3,6 @@ rancher:
   environment:
     ETCD_DISCOVERY: https://discovery.etcd.io/c2c219023108cda9529364d6d983fe13
     FLANNEL_NETWORK: 10.244.0.0/16
-  services_include:
-    kernel-headers: true
   network:
     interfaces:
       eth*:

--- a/tests/assets/test_22/cloud-config.yml
+++ b/tests/assets/test_22/cloud-config.yml
@@ -1,0 +1,6 @@
+#cloud-config
+rancher:
+  services_include:
+    kernel-headers: true
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -66,27 +66,6 @@ func (s *QemuSuite) RunQemu(additionalArgs ...string) error {
 	return s.WaitForSSH()
 }
 
-func (s *QemuSuite) RestartQemu(additionalArgs ...string) error {
-	s.qemuCmd.Process.Kill()
-	time.Sleep(time.Millisecond * 1000)
-
-	runArgs := []string{
-		"--qemu",
-		"--no-rebuild",
-		"--no-rm-usr",
-	}
-	runArgs = append(runArgs, additionalArgs...)
-
-	s.qemuCmd = exec.Command(s.runCommand, runArgs...)
-	s.qemuCmd.Stdout = os.Stdout
-	s.qemuCmd.Stderr = os.Stderr
-	if err := s.qemuCmd.Start(); err != nil {
-		return err
-	}
-
-	return s.WaitForSSH()
-}
-
 func (s *QemuSuite) WaitForSSH() error {
 	sshArgs := []string{
 		"--qemu",
@@ -124,9 +103,10 @@ func (s *QemuSuite) CheckCall(c *C, additionalArgs ...string) {
 	c.Assert(s.MakeCall(additionalArgs...), IsNil)
 }
 
-func (s *QemuSuite) Reboot() {
+func (s *QemuSuite) Reboot(c *C) {
 	s.MakeCall("sudo reboot")
 	time.Sleep(3000 * time.Millisecond)
+	c.Assert(s.WaitForSSH(), IsNil)
 }
 
 func (s *QemuSuite) LoadInstallerImage(c *C) {

--- a/tests/docker_in_persistent_console_test.go
+++ b/tests/docker_in_persistent_console_test.go
@@ -14,7 +14,7 @@ func (s *QemuSuite) TestRebootWithContainerRunning(c *C) {
 set -e -x
 docker run -d --restart=always %s`, NginxImage))
 
-	s.Reboot()
+	s.Reboot(c)
 
 	s.CheckCall(c, "docker ps -f status=running | grep nginx")
 }

--- a/tests/http_proxy_test.go
+++ b/tests/http_proxy_test.go
@@ -19,7 +19,7 @@ else
     exit 0
 fi`)
 
-	s.RestartQemu("--cloud-config", "./tests/assets/test_17/cloud-config.yml")
+	s.Reboot(c)
 
 	s.CheckCall(c, `
 set -x -e

--- a/tests/kernel_headers_test.go
+++ b/tests/kernel_headers_test.go
@@ -1,0 +1,12 @@
+package integration
+
+import . "gopkg.in/check.v1"
+
+func (s *QemuSuite) TestKernelHeaders(c *C) {
+	err := s.RunQemu("--cloud-config", "./tests/assets/test_22/cloud-config.yml")
+	c.Assert(err, IsNil)
+
+	s.CheckCall(c, `
+sleep 10
+docker inspect kernel-headers`)
+}

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -28,8 +28,4 @@ for i in $(pidof docker); do
     fi
 done
 [ "$found" = "true" ]`)
-
-	s.CheckCall(c, `
-sleep 5
-docker inspect kernel-headers`)
 }

--- a/tests/oem_test.go
+++ b/tests/oem_test.go
@@ -3,14 +3,14 @@ package integration
 import . "gopkg.in/check.v1"
 
 func (s *QemuSuite) TestOem(c *C) {
-	err := s.RunQemu("--append", "rancher.state.dev=x")
+	err := s.RunQemu("--second-drive")
 	c.Assert(err, IsNil)
 
 	s.CheckCall(c, `
 set -x
 set -e
-sudo mkfs.ext4 -L RANCHER_OEM /dev/vda
-sudo mount /dev/vda /mnt
+sudo mkfs.ext4 -L RANCHER_OEM /dev/vdb
+sudo mount /dev/vdb /mnt
 cat > /tmp/oem-config.yml << EOF
 #cloud-config
 rancher:
@@ -20,10 +20,11 @@ EOF
 sudo cp /tmp/oem-config.yml /mnt
 sudo umount /mnt`)
 
-	s.Reboot()
+	s.Reboot(c)
 
 	s.CheckCall(c, `
 set -x
+set -e
 if [ ! -e /usr/share/ros/oem/oem-config.yml ]; then
     echo Failed to find /usr/share/ros/oem/oem-config.yml
     exit 1


### PR DESCRIPTION
Sets the ISO to no longer use the `RANCHER_STATE` drive by default. Adds a `rancher.root` cloud-config key to configure the root drive. Whenever this key is specified, wait for the root drive to be initialized.

#670 
#662 
#850 