### PR TITLE
Strip more Docker binaries from DFS image

### DIFF
--- a/scripts/layout
+++ b/scripts/layout
@@ -22,6 +22,7 @@ ln -s usr/bin/ros              ${INITRD_DIR}/init
 ln -s bin                      ${INITRD_DIR}/usr/sbin
 ln -s usr/sbin                 ${INITRD_DIR}/sbin
 ln -s ros                      ${INITRD_DIR}/usr/bin/system-docker
+ln -s ros                      ${INITRD_DIR}/usr/bin/docker-runc
 ln -s ../../../../usr/bin/ros  ${INITRD_DIR}/usr/var/lib/cni/bin/bridge
 ln -s ../../../../usr/bin/ros  ${INITRD_DIR}/usr/var/lib/cni/bin/host-local
 
@@ -52,8 +53,7 @@ fi
 DFS_ARCH=$(docker create ${DFS_IMAGE}${SUFFIX})
 trap "docker rm -fv ${DFS_ARCH} >/dev/null" EXIT
 
-docker export ${DFS_ARCH} | tar xf - -C ${INITRD_DIR} --exclude=usr/bin/dockerlaunch \
-                                                      --exclude=usr/bin/docker       \
+docker export ${DFS_ARCH} | tar xf - -C ${INITRD_DIR} --exclude=usr/bin/docker*      \
                                                       --exclude=usr/share/git-core   \
                                                       --exclude=usr/bin/git          \
                                                       --exclude=usr/bin/ssh          \


### PR DESCRIPTION
Remove some unnecessary Docker binaries that were included in the last RC. The final ISO size was bigger than it should have been as a result of this.