### PR TITLE
Fix duplicate volumes_from when switching consoles

### DIFF
--- a/cmd/switchconsole/switch_console.go
+++ b/cmd/switchconsole/switch_console.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
+	composeConfig "github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/options"
 	"github.com/rancher/os/compose"
 	"github.com/rancher/os/config"
@@ -24,6 +25,8 @@ func Main() {
 	}
 
 	if newConsole != "default" {
+                project.ServiceConfigs.Add("console", &composeConfig.ServiceConfig{})
+
 		if err = compose.LoadService(project, cfg, true, newConsole); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Fixes an issue where `all-volumes` would show up twice in `VolumesFrom` for the console container after using `ros console switch`.