### PR TITLE
Remove -s overlay from rancher.docker.args as overlay is used by default

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -387,4 +387,4 @@ rancher:
     engine: docker-1.11.2
     tls_args: [--tlsverify, --tlscacert=/etc/docker/tls/ca.pem, --tlscert=/etc/docker/tls/server-cert.pem, --tlskey=/etc/docker/tls/server-key.pem,
       '-H=0.0.0.0:2376']
-    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -s, overlay, -G, docker, -H, 'unix:///var/run/docker.sock']
+    args: [daemon, --log-opt, max-size=25m, --log-opt, max-file=2, -G, docker, -H, 'unix:///var/run/docker.sock']


### PR DESCRIPTION
Remove -s overlay from rancher.docker.args as overlay is used by default

This change will make it easier to customize docker storage by adding arguments to rancher.docker.extra_args and not having to overwrite rancher.docker.args list.