### PR TITLE
Implement runcmd

### DIFF
--- a/cmd/cloudinitexecute/cloudinitexecute.go
+++ b/cmd/cloudinitexecute/cloudinitexecute.go
@@ -89,6 +89,20 @@ func ApplyConsole(cfg *rancherConfig.CloudConfig) {
 			log.Errorf("Failed to mount %s: %v", mount[1], err)
 		}
 	}
+
+	for _, runcmd := range cfg.Runcmd {
+		if len(runcmd) == 0 {
+			continue
+		}
+
+		cmd := exec.Command(runcmd[0], runcmd[1:]...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Errorf("Failed to run %s: %v", runcmd, err)
+		}
+	}
 }
 
 func WriteFiles(cfg *rancherConfig.CloudConfig, container string) {

--- a/config/types.go
+++ b/config/types.go
@@ -89,6 +89,7 @@ type CloudConfig struct {
 	Hostname          string        `yaml:"hostname"`
 	Mounts            [][]string    `yaml:"mounts,omitempty"`
 	Rancher           RancherConfig `yaml:"rancher,omitempty"`
+	Runcmd            [][]string    `yaml:"runcmd,omitempty"`
 }
 
 type File struct {

--- a/tests/assets/test_26/cloud-config.yml
+++ b/tests/assets/test_26/cloud-config.yml
@@ -1,0 +1,14 @@
+#cloud-config
+write_files:
+- path: /usr/bin/test
+  permissions: "0755"
+  owner: root
+  content: |
+    #!/bin/bash
+    touch /home/rancher/test
+runcmd:
+- []
+- [ test ]
+- [ touch, /home/rancher/test2 ]
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/runcmd_test.go
+++ b/tests/runcmd_test.go
@@ -1,0 +1,11 @@
+package integration
+
+import . "gopkg.in/check.v1"
+
+func (s *QemuSuite) TestRuncmd(c *C) {
+	err := s.RunQemu("--cloud-config", "./tests/assets/test_26/cloud-config.yml")
+	c.Assert(err, IsNil)
+
+	s.CheckCall(c, "ls /home/rancher | grep test")
+	s.CheckCall(c, "ls /home/rancher | grep test2")
+}


### PR DESCRIPTION
Provides an implementation of the cloud-init `runcmd` key. Currently only supports the list syntax, whereas cloud-init also provides the option of specifying commands as strings.

By design, RancherOS will run all of the commands on each boot. This differs from cloud-init which runs all of the commands only once.

#1102 