### PR TITLE
Do not ask about reboot if --force and no --no-reboot

### DIFF
--- a/cmd/control/install.go
+++ b/cmd/control/install.go
@@ -116,7 +116,7 @@ func runInstall(image, installType, cloudConfig, device string, force, reboot bo
 		return err
 	}
 
-	if reboot && yes(in, "Continue with reboot") {
+	if reboot && (force || yes(in, "Continue with reboot")) {
 		log.Info("Rebooting")
 		power.Reboot()
 	}


### PR DESCRIPTION
When "--force" flag and no "--no-reboot" flag present then do not ask about reboot confirmation.

Otherwise hack like `yes | ros install --force ...` is still needed.

Such behaviour is necessary to install system from scripts over ssh. I use command like this (from Ansible):

`ssh rancherhost sudo ros install --force --cloud-config RancherOS.yml --device /dev/sda`

I haven't compiled a new ISO with the patch nor tested it yet but this one line change should do the trick.