### PR TITLE
Add EFI live boot support

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,6 +20,7 @@ RUN apt-get update && \
         gccgo \
         genisoimage \
         git \
+        grub-efi \
         isolinux \
         less \
         libblkid-dev \

--- a/efi.txt
+++ b/efi.txt
@@ -1,0 +1,28 @@
+To install with EFI:
+
+A: install grub-efi
+
+apt install grub-efi
+
+B: Add to the installation process in scripts/package-iso
+
+1. Make directories ${CD}/boot/grub and ${CD}/EFI/BOOT
+2. Install the various grub modules from /usr/lib/grub/x86_64-efi/ to ${CD}/boot/grub/x86_64-efi/
+3. Copy scripts/grub.cfg to ${CD}/boot/grub/grub.cfg
+4. Run grub-mkimage to create the grub image: 
+
+(cd ${CD} && grub-mkimage  -O x86_64-efi -o EFI/BOOT/BOOTX64.EFI --config=boot/grub/grub.cfg --compression=auto --prefix='()/boot/grub' disk part_msdos fat iso9660 )
+
+NOTE: do *NOT* try to install the linux module directly in the grub image; it causes command-line options not to be passed and is a known bug.
+
+5. Add the following xorriso options
+
+    -eltorito-alt-boot -e EFI/BOOT/BOOTX64.EFI -no-emul-boot \
+    -isohybrid-gpt-basdat \
+
+This installation includes *no* additional icons or drivers. It is just meant to get RancherOS booted on an EFI system.
+If you want to add support for graphical installations, additional filesystems, and everything else.... you will need a lot more 
+
+
+
+

--- a/scripts/grub.cfg
+++ b/scripts/grub.cfg
@@ -8,7 +8,7 @@ insmod efi_uga
 
 menuentry "Rancher" {
         set gfxpayload=keep
-        linux   /boot/vmlinuz  quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
+        linux   /boot/vmlinuz quiet rancher.autologin=tty1 rancher.autologin=ttyS0
         initrd  /boot/initrd
 }
 

--- a/scripts/grub.cfg
+++ b/scripts/grub.cfg
@@ -1,0 +1,14 @@
+set default="0"
+set timeout=10
+
+set gfxmode=auto
+insmod efi_gop
+insmod efi_uga
+
+
+menuentry "Rancher" {
+        set gfxpayload=keep
+        linux   /boot/vmlinuz  quiet rancher.password=rancher rancher.state.autoformat=[/dev/sda,/dev/vda]
+        initrd  /boot/initrd
+}
+

--- a/scripts/package-iso
+++ b/scripts/package-iso
@@ -9,7 +9,7 @@ CD=${BUILD}/cd
 ISO=${ARTIFACTS}/$(echo ${DISTRIB_ID} | tr '[:upper:]' '[:lower:]').iso
 CHECKSUM=iso-checksums.txt
 
-mkdir -p ${CD}/boot/isolinux
+## TRADITIONAL MBR BOOT
 mkdir -p ${CD}/boot/isolinux
 
 if [ ! -f ${ARTIFACTS}/vmlinuz ] || [ ! -f ${ARTIFACTS}/initrd ]; then
@@ -21,12 +21,42 @@ cp ${ARTIFACTS}/vmlinuz                       ${CD}/boot
 cp scripts/isolinux.cfg                       ${CD}/boot/isolinux
 cp /usr/lib/ISOLINUX/isolinux.bin             ${CD}/boot/isolinux
 cp /usr/lib/syslinux/modules/bios/ldlinux.c32 ${CD}/boot/isolinux
+
+
+## EFI BOOT
+mkdir -p ${CD}/EFI/BOOT
+mkdir -p ${CD}/boot/grub
+cp scripts/grub.cfg ${CD}/boot/grub
+cp -r /usr/lib/grub/x86_64-efi/ ${CD}/boot/grub
+
+(cd ${CD} && grub-mkimage  -O x86_64-efi -o EFI/BOOT/BOOTX64.EFI --config=boot/grub/grub.cfg --compression=auto --prefix='()/boot/grub' disk part_msdos fat iso9660 )
+
+# make the EFI FAT filesystem to boot
+EFIIMG=boot/efiboot.img
+CDEFI=${CD}/${EFIIMG}
+rm -f ${CDEFI}
+dd if=/dev/zero of=${CDEFI} bs=4k count=1000
+mkfs.vfat ${CDEFI}
+mkdir -p tmp/
+mount -o loop ${CDEFI} tmp/
+cp -r ${CD}/EFI tmp/
+umount tmp/
+rmdir tmp/
+
+rm -rf ${CD}/EFI
+
+
+## BUILD THE ISO IMAGE
+
 cd ${CD} && xorriso \
     -as mkisofs \
     -l -J -R -V "${DISTRIB_ID}" \
     -no-emul-boot -boot-load-size 4 -boot-info-table \
     -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
     -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
+    -eltorito-alt-boot \
+    -e ${EFIIMG} -no-emul-boot \
+    -isohybrid-gpt-basdat \
     -o $ISO ${CD}
 
 cd $(dirname $ISO)

--- a/scripts/run
+++ b/scripts/run
@@ -41,6 +41,21 @@ while [ "$#" -gt 0 ]; do
         --kvm)
             KVM=1
             ;;
+        --efi)
+            # set where our EFI firmware binary is
+            EFIFIRMWARE="./build/OVMF.fd"
+            # create the command-line to pass to qemu
+            EFI="--bios $EFIFIRMWARE"
+            # if the firmware does not yet exist, download it
+            if [[ ! -e "$EFIFIRMWARE" ]]; then
+                echo "Downloading OVMF EFI firmware"
+                # because unzip does not support streaming from stdin...
+                curl --location http://downloads.sourceforge.net/project/edk2/OVMF/OVMF-X64-r15214.zip > ./build/ovmf.zip
+                unzip ./build/ovmf.zip -d ./build OVMF.fd
+                rm -f ./build/ovmf.zip
+                echo "Download OVMF EFI firmware complete"
+            fi
+            ;;
         --no-format)
             FORMAT=0
             ;;
@@ -138,6 +153,7 @@ if [ "$QEMU" == "1" ]; then
             ${CPU} \
             ${machine["$ARCH"]} \
             -m 2048 \
+            ${EFI} \
             ${network["$ARCH"]} \
             $(eval "${hd["$ARCH"]} ${HD}") \
             ${SECOND_DRIVE_ENABLE} \
@@ -160,6 +176,7 @@ if [ "$QEMU" == "1" ]; then
             -kernel ${KERNEL} \
             -initrd ${INITRD} \
             -m 2048 \
+            ${EFI} \
             ${network["$ARCH"]} \
             $(eval "${hd["$ARCH"]} ${HD}") \
             ${SECOND_DRIVE_ENABLE} \


### PR DESCRIPTION
This is a fully rebased version of https://github.com/rancher/os/pull/938

A temporary WIP rebase was provided by @ibuildthecloud in https://github.com/rancher/os/pull/1262

Most of the conversation is there. However, as it was quiet through a few releases, it needed to be rebased against the latest master, and the PR needed to have the target be master as well.

This *only* provides live boot support. It still does not support running `ros install`. Once this is merged in, a separate PR will be provided for that.