### PR TITLE
Add latest and running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ trash-keep: .dapper
 
 deps: trash
 
-build/initrd/.id:
-	dapper prepare
+build/initrd/.id: .dapper
+	./.dapper prepare
 
-run: build/initrd/.id
-	dapper -m bind build-target
+run: build/initrd/.id .dapper
+	./.dapper -m bind build-target
 	./scripts/run
 
-shell-bind:
-	dapper -m bind -s
+shell-bind: .dapper
+	./.dapper -m bind -s
 
 clean:
 	@./scripts/clean


### PR DESCRIPTION
output:

```
RancherOS rancher-dev ttyS0
eth0: 10.0.2.15 lo: 127.0.0.1
rancher-dev login: rancher (automatic login)

INFO[0006] RancherOS c19f189-dirty started              
[rancher@rancher-dev ~]$ sudo ros os list
rancher/os:v0.6.1 remote latest 
rancher/os:v0.6.0 remote available 
rancher/os:v0.5.0 remote available 
rancher/os:v0.4.5 remote available 
rancher/os:v0.4.4 remote available 
rancher/os:v0.4.3 remote available 
rancher/os:v0.4.2 remote available 
rancher/os:v0.4.1 remote available 
rancher/os:v0.4.0 remote available 
c19f189-dirty running
[rancher@rancher-dev ~]$ 
```

(I'm not sure if "installed" or "running" is the right thing to say)

the first commit comes from #1271 - I'm presuming that can be merged first.

This PR relates to #147 and #148