### PR TITLE
Make the integration-test target run in a container as per docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ run: build/initrd/.id .dapper
 	./.dapper -m bind build-target
 	./scripts/run
 
+integration-test: .dapper
+	./.dapper -m bind integration-test
+
 shell-bind: .dapper
 	./.dapper -m bind -s
 


### PR DESCRIPTION
the contribution doc says it runs in a container - and I tend not to have go installed in the shell/os/container I'm running make from.

@ibuildthecloud @joshwget do you guys run the scripts directly, or use make?