### PR TITLE
Remove read-only mounts from cloud-init-execute

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -145,8 +145,10 @@ rancher:
       uts: host
       privileged: true
       volumes_from:
-      - command-volumes
       - system-volumes
+      volumes:
+      - /usr/bin/ros:/usr/bin/ros
+      - /usr/bin/ros:/usr/bin/cloud-init-execute
     cloud-init-pre:
       image: {{.OS_REPO}}/os-cloudinit:{{.VERSION}}{{.SUFFIX}}
       environment:


### PR DESCRIPTION
`resize2fs` looks at mount points for the device it's trying to resize. If the first one it finds is a read-only mount then it will fail with `resize2fs: Read-only file system While checking for on-line resizing support`.

#1237 