### PR TITLE
cope with new console types (like ttyUSB0) and baudrates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ func Get(key string) (interface{}, error) {
 	return v, nil
 }
 
+// Get rancher. boot params
 func GetCmdline(key string) interface{} {
 	cmdline := readCmdline()
 	v, _ := getOrSetVal(key, cmdline, nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -302,3 +302,22 @@ func TestUserDocker(t *testing.T) {
 	assert.True(v.(bool))
 
 }
+
+func TestGetCmdline(t *testing.T) {
+	assert := require.New(t)
+
+	cmdline := `rancher.password=pass! rancher.console=alpine rancher.console=ubuntu this="is a trick" console=tty0 console=ttyAMA0 console=ttyS1,9600`
+	// just to make sure that yes, this won't get the non-rancher values i want
+	config := parseCmdline(cmdline)
+	assert.Equal(map[interface{}]interface{}{
+		"rancher": map[interface{}]interface{}{
+			"password": "pass!",
+			"console":  "ubuntu",
+		},
+	}, config)
+
+	consoles := GetCmdLineValues(cmdline, "console")
+	assert.Equal([]string{"tty0", "ttyAMA0", "ttyS1,9600"}, consoles)
+
+	assert.Equal([]string{`"is a trick"`}, GetCmdLineValues(cmdline, "this"))
+}


### PR DESCRIPTION
fell down a rabbit hole, and used it to explore more of the codebase.

we now support any `console=ttyNEW,9600` that we didn't put into the code, and don't lose the baudrate setting, and don't autologin on `tty10` if `autologin=tty1` was specified.
