### PR TITLE
Add tests for when state fails to mount

### DIFF
--- a/tests/bad_state_test.go
+++ b/tests/bad_state_test.go
@@ -1,0 +1,15 @@
+package integration
+
+import . "gopkg.in/check.v1"
+
+func (s *QemuSuite) TestBadState(c *C) {
+	err := s.RunQemu("--no-format", "--append", "rancher.state.dev=LABEL=BAD_STATE")
+	c.Assert(err, IsNil)
+	s.CheckCall(c, "mount | grep /var/lib/docker | grep rootfs")
+}
+
+func (s *QemuSuite) TestBadStateWithWait(c *C) {
+	err := s.RunQemu("--no-format", "--append", "rancher.state.dev=LABEL=BAD_STATE", "--append", "rancher.state.wait")
+	c.Assert(err, IsNil)
+	s.CheckCall(c, "mount | grep /var/lib/docker | grep rootfs")
+}


### PR DESCRIPTION
Inspired by #1243. We don't currently have any tests ensuring that RancherOS falls back to running from memory when it fails to mount state.