### PR TITLE
Add a way to over-ride the downloaded kernel with a local file

### DIFF
--- a/scripts/layout
+++ b/scripts/layout
@@ -31,6 +31,12 @@ touch ${INITRD_DIR}/usr/bin/docker-containerd
 touch ${INITRD_DIR}/usr/bin/docker-containerd-shim
 touch ${INITRD_DIR}/usr/bin/docker
 
+# Override using a local kernel build
+if [ -e ${DAPPER_SOURCE}/assets/kernel.tar.gz ]; then
+    echo "copying ${DAPPER_SOURCE}/assets/kernel.tar.gz ${DOWNLOADS}/kernel.tar.gz"
+    cp ${DAPPER_SOURCE}/assets/kernel.tar.gz ${DOWNLOADS}/kernel.tar.gz
+fi
+
 if [ -e ${DOWNLOADS}/kernel.tar.gz ]; then
     mkdir -p ${BUILD}/kernel
     tar xf ${DOWNLOADS}/kernel.tar.gz -C ${BUILD}/kernel


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

goes with https://github.com/rancher/os-kernel/pull/30

This change will mean anyone can build a "random" kernel, then run `./script/package-kernel` in `os-kernel`, then copy the `kernel.tar.gz` into the `assets` dir of the `os` project and build an iso without needing to upload files.