### PR TITLE
Write /run/console-done before executing /etc/rc.local

### DIFF
--- a/cmd/console/console.go
+++ b/cmd/console/console.go
@@ -111,6 +111,11 @@ func Main() {
 	if err := runScript(startScript); err != nil {
 		log.Error(err)
 	}
+
+	if err := ioutil.WriteFile(consoleDone, []byte(cfg.Rancher.Console), 0644); err != nil {
+		log.Error(err)
+	}
+
 	if err := runScript("/etc/rc.local"); err != nil {
 		log.Error(err)
 	}
@@ -120,10 +125,6 @@ func Main() {
 	respawnBinPath, err := exec.LookPath("respawn")
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	if err := ioutil.WriteFile(consoleDone, []byte(cfg.Rancher.Console), 0644); err != nil {
-		log.Error(err)
 	}
 
 	log.Fatal(syscall.Exec(respawnBinPath, []string{"respawn", "-f", "/etc/respawn.conf"}, os.Environ()))

--- a/tests/assets/test_26/cloud-config.yml
+++ b/tests/assets/test_26/cloud-config.yml
@@ -15,13 +15,14 @@ write_files:
   permissions: "0755"
   owner: root
   content: |
-    touch /home/rancher/test4
+    wait-for-docker
+    docker run -d nginx
 - path: /var/lib/rancher/conf/cloud-config-script
   permissions: "0755"
   owner: root
   content: |
     #!/bin/bash
-    touch /home/rancher/test5
+    touch /home/rancher/test4
 runcmd:
 - []
 - [ test ]

--- a/tests/start_commands_test.go
+++ b/tests/start_commands_test.go
@@ -10,7 +10,8 @@ func (s *QemuSuite) TestStartCommands(c *C) {
 	err := s.RunQemu("--cloud-config", "./tests/assets/test_26/cloud-config.yml")
 	c.Assert(err, IsNil)
 
-	for i := 1; i < 6; i++ {
+	for i := 1; i < 5; i++ {
 		s.CheckCall(c, fmt.Sprintf("ls /home/rancher | grep test%d", i))
 	}
+	s.CheckCall(c, "docker ps | grep nginx")
 }


### PR DESCRIPTION
Restores execution order around start scripts to how it was before the console initialization script was rewritten in Go.

#1223 