### PR TITLE
Seperate SSH check from Docker check in tests

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -85,14 +85,31 @@ func (s *QemuSuite) runQemu(args ...string) error {
 func (s *QemuSuite) WaitForSSH() error {
 	sshArgs := []string{
 		"--qemu",
+		"true",
+	}
+
+	var err error
+	for i := 0; i < 100; i++ {
+		cmd := exec.Command(s.sshCommand, sshArgs...)
+		if err = cmd.Run(); err == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to connect to SSH: %v", err)
+	}
+
+	sshArgs = []string{
+		"--qemu",
 		"docker",
 		"version",
 		">/dev/null",
 		"2>&1",
 	}
 
-	var err error
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 20; i++ {
 		cmd := exec.Command(s.sshCommand, sshArgs...)
 		if err = cmd.Run(); err == nil {
 			return nil
@@ -100,7 +117,7 @@ func (s *QemuSuite) WaitForSSH() error {
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	return fmt.Errorf("Failed to connect to SSH: %v", err)
+	return fmt.Errorf("Failed to check Docker version: %v", err)
 }
 
 func (s *QemuSuite) MakeCall(additionalArgs ...string) error {


### PR DESCRIPTION
Makes it easier to determine if a test fails from not being able to SSH versus not being able to connect to Docker.