### PR TITLE
Kernel args like ssh_authorized_keys='["ssh_rsa foopubkey"]', i.e. top level and with spaces

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -120,7 +120,7 @@ func TestParseCmdline(t *testing.T) {
 		"rancher": map[interface{}]interface{}{
 			"key": "a\nb",
 		},
-	}, parseCmdline("rancher.key=a\nb"))
+	}, parseCmdline("rancher.key=\"a\nb\""))
 
 	assert.Equal(map[interface{}]interface{}{
 		"rancher": map[interface{}]interface{}{

--- a/config/data_funcs.go
+++ b/config/data_funcs.go
@@ -3,7 +3,7 @@ package config
 import (
 	log "github.com/Sirupsen/logrus"
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
-
+	shellwords "github.com/mattn/go-shellwords"
 	"strings"
 
 	"github.com/rancher/os/util"
@@ -156,13 +156,21 @@ func unmarshalOrReturnString(value string) (result interface{}) {
 
 func parseCmdline(cmdLine string) map[interface{}]interface{} {
 	result := make(map[interface{}]interface{})
+	params, err := shellwords.Parse(cmdLine)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err, "cmdline": cmdLine}).Error("Failed to parse kernel params")
+		return result
+	}
 
 outer:
-	for _, part := range strings.Split(cmdLine, " ") {
-		if !strings.HasPrefix(part, "rancher.") {
+	for _, part := range params {
+		if true &&
+			!strings.HasPrefix(part, "rancher.") &&
+			!strings.HasPrefix(part, "ssh_authorized_keys=") &&
+			!strings.HasPrefix(part, "hostname=") &&
+			!strings.HasPrefix(part, "default_hostname=") {
 			continue
 		}
-
 		var value string
 		kv := strings.SplitN(part, "=", 2)
 

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -14,4 +14,4 @@ if [ ! -e ../dist/artifacts/initrd ]; then
     ../scripts/dev
 fi
 
-go test -timeout 30m
+go test -v -check.vv -timeout 30m

--- a/scripts/test
+++ b/scripts/test
@@ -11,4 +11,4 @@ PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u
 if [ "$ARCH" = "amd64" ]; then
     RACE="-race"
 fi
-go test $RACE -cover -tags=test ${PACKAGES}
+go test -v -check.vv $RACE -cover -tags=test ${PACKAGES}

--- a/vendor/github.com/mattn/go-shellwords/.travis.yml
+++ b/vendor/github.com/mattn/go-shellwords/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
   - tip
 before_install:
-  - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 script:

--- a/vendor/github.com/mattn/go-shellwords/shellwords_test.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords_test.go
@@ -1,0 +1,132 @@
+package shellwords
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+var testcases = []struct {
+	line     string
+	expected []string
+}{
+	{`var --bar=baz`, []string{`var`, `--bar=baz`}},
+	{`var --bar="baz"`, []string{`var`, `--bar=baz`}},
+	{`var "--bar=baz"`, []string{`var`, `--bar=baz`}},
+	{`var "--bar='baz'"`, []string{`var`, `--bar='baz'`}},
+	{"var --bar=`baz`", []string{`var`, "--bar=`baz`"}},
+	{`var "--bar=\"baz'"`, []string{`var`, `--bar="baz'`}},
+	{`var "--bar=\'baz\'"`, []string{`var`, `--bar='baz'`}},
+	{`var --bar='\'`, []string{`var`, `--bar=\`}},
+	{`var "--bar baz"`, []string{`var`, `--bar baz`}},
+	{`var --"bar baz"`, []string{`var`, `--bar baz`}},
+	{`var  --"bar baz"`, []string{`var`, `--bar baz`}},
+}
+
+func TestSimple(t *testing.T) {
+	for _, testcase := range testcases {
+		args, err := Parse(testcase.line)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if !reflect.DeepEqual(args, testcase.expected) {
+			t.Fatalf("Expected %v, but %v:", testcase.expected, args)
+		}
+	}
+}
+
+func TestError(t *testing.T) {
+	_, err := Parse("foo '")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+	_, err = Parse(`foo "`)
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+
+	_, err = Parse("foo `")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+}
+
+func TestBacktick(t *testing.T) {
+	goversion, err := shellRun("go version")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	parser := NewParser()
+	parser.ParseBacktick = true
+	args, err := parser.Parse("echo `go version`")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", goversion}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestBacktickError(t *testing.T) {
+	parser := NewParser()
+	parser.ParseBacktick = true
+	_, err := parser.Parse("echo `go Version`")
+	if err == nil {
+		t.Fatalf("Should be an error")
+	}
+}
+
+func TestEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $FOO")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", "bar"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestNoEnv(t *testing.T) {
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $BAR")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", ""}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}
+
+func TestDupEnv(t *testing.T) {
+	os.Setenv("FOO", "bar")
+	os.Setenv("FOO_BAR", "baz")
+
+	parser := NewParser()
+	parser.ParseEnv = true
+	args, err := parser.Parse("echo $$FOO$")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := []string{"echo", "$bar$"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+
+	args, err = parser.Parse("echo $${FOO_BAR}$")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected = []string{"echo", "$baz$"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, args)
+	}
+}


### PR DESCRIPTION
Quotes double and single handled properly like in shell. Very important for network or local diskless/stateless booting. Tested in production as well as 'test' and 'integration-test' passed.