### PR TITLE
move the kernel headers and extras images to os repo

### DIFF
--- a/images/10-extras/Dockerfile
+++ b/images/10-extras/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.4
+# FROM arm64=skip arm=skip
+RUN apk --purge --no-cache add kmod bash openssl
+COPY extra.sh  /usr/bin
+CMD ["extra.sh"]

--- a/images/10-extras/extra.sh
+++ b/images/10-extras/extra.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+DIR=$(readlink /lib/modules/$(uname -r)/build)
+STAMP=/lib/modules/$(uname -r)/.extra-done
+VER=$(basename $DIR)
+URL=${KERNEL_EXTRAS_URL:-https://github.com/rancher/os-kernel/releases/download/${VER}/extra.tar.gz}
+
+if [ -e $STAMP ]; then
+    echo Kernel extras already installed. Delete $STAMP to reinstall
+    exit 0
+fi
+
+echo Downloading $URL
+wget -O - $URL | gzip -dc | tar xf - -C /
+depmod -a
+touch $STAMP
+
+echo Kernel extras installed

--- a/images/10-headers/Dockerfile
+++ b/images/10-headers/Dockerfile
@@ -1,0 +1,3 @@
+FROM rancher/os-base
+COPY headers.sh  /
+CMD ["/headers.sh"]

--- a/images/10-headers/headers.sh
+++ b/images/10-headers/headers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+DIR=$(readlink /lib/modules/$(uname -r)/build)
+STAMP=${DIR}/.done
+VER=$(basename $DIR)
+
+if [ "$VER" = "Ubuntu-4.4.0-23.41-rancher2" ]; then
+    VER=Ubuntu-4.4.0-23.41-rancher2-2
+fi
+
+KERNEL_HEADERS_URL=${KERNEL_HEADERS_URL:-https://github.com/rancher/os-kernel/releases/download/${VER}/build.tar.gz}
+
+if [ -e $STAMP ]; then
+    echo Headers already installed in $DIR
+    exit 0
+fi
+
+echo Downloading $KERNEL_HEADERS_URL
+mkdir -p $DIR
+wget -O - $KERNEL_HEADERS_URL | gzip -dc | tar xf - -C $DIR
+touch $STAMP
+
+echo Headers installed at $DIR


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

initially moving the kernel image builds into the os repo from https://github.com/rancher/os-images/pull/114

later will contemplate if they should move to os-kernel.

see https://github.com/rancher/os-images/pull/114
