### PR TITLE
Add 'Custom Builds' section to docs

### DIFF
--- a/docs/_includes/os-sidebar.html
+++ b/docs/_includes/os-sidebar.html
@@ -88,8 +88,6 @@
                         <li><a href="{{site.baseurl}}/os/configuration/loading-kernel-modules/">Loading kernel modules</a></li>
                         <li><a href="{{site.baseurl}}/os/configuration/kernel-modules-kernel-headers/">Install kernel modules that require kernel headers</a></li>
                         <li><a href="{{site.baseurl}}/os/configuration/dkms/">DKMS</a></li>
-                        <li><a href="{{site.baseurl}}/os/configuration/custom-kernels/">Custom Kernels</a></li>
-                        <li><a href="{{site.baseurl}}/os/configuration/custom-rancheros-iso/">Building custom RancherOS ISO</a></li>
                     </ul>
                 </li>
                 <li class="panel">
@@ -115,6 +113,13 @@
                         <li><a href="{{site.baseurl}}/os/networking/interfaces/">Interfaces</a></li>
                         <li><a href="{{site.baseurl}}/os/networking/dns/">DNS</a></li>
                         <li><a href="{{site.baseurl}}/os/networking/proxy-settings/">Proxy Settings</a></li>
+                    </ul>
+                </li>
+                <li class="panel">
+                    <a href="#custombuilds"  data-toggle="collapse" class="collapsed" data-parent="#mainmenu">Custom Builds<i class="pull-right fa fa-angle-down"></i><i class="pull-right fa fa-angle-up"></i></a>
+                    <ul class="collapse list-group-submenu" id="custombuilds">
+                        <li><a href="{{site.baseurl}}/os/custom-builds/custom-rancheros-iso/">Custom RancherOS ISO</a></li>
+                        <li><a href="{{site.baseurl}}/os/custom-builds/custom-kernels/">Custom Kernels</a></li>
                     </ul>
                 </li>
                 <li><a href="{{site.baseurl}}/os/upgrading/">Upgrading</a></li>

--- a/docs/os/custom-builds/custom-kernels/index.md
+++ b/docs/os/custom-builds/custom-kernels/index.md
@@ -1,7 +1,8 @@
 ---
 title: Custom Kernels in RancherOS
 layout: os-default
-
+redirect_from:
+  - os/configuration/custom-kernels/
 ---
 
 ## Custom Kernels

--- a/docs/os/custom-builds/custom-rancheros-iso/index.md
+++ b/docs/os/custom-builds/custom-rancheros-iso/index.md
@@ -1,7 +1,8 @@
 ---
 title: Custom RancherOS ISO
 layout: os-default
-
+redirect_from:
+  - os/configuration/custom-rancheros-iso/
 ---
 
 ## Custom RancherOS ISO


### PR DESCRIPTION
The "Configuration" section has too many things under it. Docs about custom kernels and building custom ISOs makes sense to be in its own section.

Might not be too important now, but as the scope of custom builds increases it'll be better to have a separate area for this in the docs.