### PR TITLE
Use symlinks for power commands instead of bind mounts

### DIFF
--- a/cmd/control/entrypoint.go
+++ b/cmd/control/entrypoint.go
@@ -45,6 +45,8 @@ func entrypointAction(c *cli.Context) error {
 		writeFiles(cfg)
 	}
 
+	setupPowerOperations()
+
 	if len(os.Args) < 3 {
 		return nil
 	}
@@ -73,4 +75,30 @@ func writeFiles(cfg *config.CloudConfig) error {
 
 	cloudinitexecute.WriteFiles(cfg, info.Name[1:])
 	return nil
+}
+
+func setupPowerOperations() {
+	for _, powerOperation := range []string{
+		"/sbin/poweroff",
+		"/sbin/shutdown",
+		"/sbin/reboot",
+		"/sbin/halt",
+		"/usr/sbin/poweroff",
+		"/usr/sbin/shutdown",
+		"/usr/sbin/reboot",
+		"/usr/sbin/halt",
+	} {
+		os.Remove(powerOperation)
+	}
+
+	for _, link := range []symlink{
+		{config.ROS_BIN, "/sbin/poweroff"},
+		{config.ROS_BIN, "/sbin/reboot"},
+		{config.ROS_BIN, "/sbin/halt"},
+		{config.ROS_BIN, "/sbin/shutdown"},
+	} {
+		if err := os.Symlink(link.oldname, link.newname); err != nil {
+			log.Error(err)
+		}
+	}
 }

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -130,10 +130,6 @@ rancher:
       volumes:
       - /usr/bin/ros:/usr/bin/dockerlaunch:ro
       - /usr/bin/ros:/usr/bin/system-docker:ro
-      - /usr/bin/ros:/sbin/poweroff:ro
-      - /usr/bin/ros:/sbin/reboot:ro
-      - /usr/bin/ros:/sbin/halt:ro
-      - /usr/bin/ros:/sbin/shutdown:ro
       - /usr/bin/ros:/usr/bin/respawn:ro
       - /usr/bin/ros:/usr/bin/ros:ro
       - /usr/bin/ros:/usr/bin/cloud-init-execute:ro


### PR DESCRIPTION
Removal of power operations is currently done during the build process of consoles. Moving it to be done in the entrypoint allows us to remove this step from the build process and simplify it a bit.

#1399