### PR TITLE
Remove unnecessary label from cloud-init service

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -37,7 +37,6 @@ rancher:
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
-        io.rancher.os.after: ntp
       log_driver: json-file
       net: host
       uts: host


### PR DESCRIPTION
Extra label that came from #1364. Likely an artifact from copying and pasting the older cloud-init service.