### PR TITLE
Fix cloud-init-execute service volumes

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -115,8 +115,10 @@ rancher:
       uts: host
       privileged: true
       volumes_from:
-      - command-volumes
       - system-volumes
+      volumes:
+      - /usr/bin/ros:/usr/bin/ros
+      - /usr/bin/ros:/usr/bin/cloud-init-execute
     command-volumes:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: echo


### PR DESCRIPTION
An incorrect merge added `command-volumes` and removed `volumes` from the `cloud-init-execute` service. Revert to how this service was before that point.

Reasoning behind why these volumes are different than other services can be found in #1299.