### PR TITLE
Changes needed to get the arm and arm64 builds working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGETS := $(shell ls scripts | grep -vE 'clean|run|help|docs')
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m|sed 's/v7l//'` > .dapper.tmp
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper

--- a/scripts/installer/Dockerfile.arm64
+++ b/scripts/installer/Dockerfile.arm64
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y parted git gcc make autoconf
 
 RUN mkdir -p /usr/local/src && \
     cd /usr/local/src && \
-    git clone https://git.linaro.org/people/takahiro.akashi/kexec-tools.git && \
-    cd kexec-tools && git checkout kdump/for-14 && ./bootstrap && ./configure && make && make install
+    git clone -b kdump/v0.14 https://git.linaro.org/people/takahiro.akashi/kexec-tools.git && \
+    cd kexec-tools && ./bootstrap && ./configure && make && make install
 
 COPY conf lay-down-os seed-data set-disk-partitions /scripts/
 COPY ./build/vmlinuz /dist/vmlinuz

--- a/scripts/version
+++ b/scripts/version
@@ -18,5 +18,8 @@ export VERSION COMMIT
 # Suffix
 export SUFFIX=""
 if [ -n "${ARCH}" ] && [ "${ARCH}" != "amd64" ]; then
+    # TODO: why is this not exported?
     SUFFIX="_${ARCH}"
 fi
+
+echo " Building ${VERSION} from ${COMMIT} on ${ARCH}"


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

it seems the kexec repo has been remodeled. removing `master` is a pretty good way to tell users of your repo that stuff has changed. 