### PR TITLE
Built v0.8.0-rc1 rpi image

### DIFF
--- a/scripts/images/raspberry-pi-hypriot/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot/Dockerfile.dapper
@@ -8,12 +8,15 @@ RUN mkdir -p /source/assets
 
 # RancherOS for ARM
 RUN curl -fL https://releases.rancher.com/os/latest/rootfs_arm.tar.gz > /source/assets/rootfs_arm.tar.gz
+#COPY rootfs_arm.tar.gz /source/assets/rootfs_arm.tar.gz
 
-# Hypriot Kernel 4.1.17+ and bootfiles for RPi2
-RUN curl -fL http://downloads.hypriot.com/raspberrypi-bootloader_20160212-075712_armhf.deb > /source/assets/raspberrypi-bootloader_20160212-075712_armhf.deb
-
-# Bootfiles to support Raspberry Pi 3 B
-RUN curl -fL http://downloads.hypriot.com/rpi3-bootfiles.tar.gz > /source/assets/rpi3-bootfiles.tar.gz
+# 4.4.27-hypriotos-v7+
+# see https://packagecloud.io/Hypriot/rpi/?filter=debs
+ENV URL=https://packagecloud.io/Hypriot/rpi/packages/debian/jessie/
+RUN curl -fL $URL/raspberrypi-kernel_20161028-083330_armhf.deb/download \
+	> /source/assets/kernel.deb
+RUN curl -fL $URL/raspberrypi-bootloader_20161028-083330_armhf.deb/download \
+	> /source/assets/bootloader.deb
 
 WORKDIR /source
 CMD ["./scripts/build.sh"]

--- a/scripts/images/raspberry-pi-hypriot/scripts/build.sh
+++ b/scripts/images/raspberry-pi-hypriot/scripts/build.sh
@@ -6,8 +6,7 @@ cd $(dirname $0)/..
 # create build directory for assembling our image filesystem
 mkdir -p build/{boot,root,basefs} dist
 
-cp assets/raspberrypi-bootloader_*_armhf.deb build/bootloader.deb
-cp assets/rpi3-bootfiles.tar.gz build/rpi3-bootfiles.tar.gz
+cp assets/*.deb build/
 
 #---build SD card image---
 
@@ -50,12 +49,11 @@ echo "RancherOS: root partition" > build/root/root.txt
 
 # unpack and cleanup the basefs
 #- doing this on a local folder keeps our resulting image clean (no dirty blocks from a delete)
+dpkg-deb -x build/kernel.deb build/basefs
 dpkg-deb -x build/bootloader.deb build/basefs
-# upgrade Raspberry Pi bootfile for RPi3 support
-tar xvzf build/rpi3-bootfiles.tar.gz -C build/basefs/boot
 # remove RPi1 kernel, we only support RPi2 and RPi3 in ARMv7 mode
 rm -fr build/basefs/boot/kernel.img
-rm -fr build/basefs/lib/modules/{4.1.17+,4.1.17-hypriotos+}
+rm -fr build/basefs/lib/modules/{4.4.27+,4.4.27-hypriotos+}
 
 # populate kernel, bootloader and RancherOS rootfs
 cp -R build/basefs/* build/root


### PR DESCRIPTION
the Hypriot devs moved the images - and using a 4.4.27 kernel is way better, so :)

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>