### PR TITLE
CLI validation for services, console, and engines

### DIFF
--- a/tests/consoles_test.go
+++ b/tests/consoles_test.go
@@ -16,7 +16,9 @@ func (s *QemuSuite) TestConsoleCommand(c *C) {
 
 	s.CheckCall(c, `
 sudo ros console list | grep default | grep current
-sudo ros console list | grep debian | grep disabled`)
+sudo ros console list | grep debian | grep disabled
+(sudo ros console switch invalid 2>&1 || true) | grep "invalid is not a valid console"
+(sudo ros console enable invalid 2>&1 || true) | grep "invalid is not a valid console"`)
 
 	s.MakeCall("sudo ros console switch -f debian")
 	c.Assert(s.WaitForSSH(), IsNil)

--- a/tests/custom_docker_test.go
+++ b/tests/custom_docker_test.go
@@ -11,6 +11,9 @@ set -ex
 docker version | grep 1.10.3
 
 sudo ros engine list | grep 1.10.3 | grep current
+(sudo ros engine switch invalid 2>&1 || true) | grep "invalid is not a valid engine"
+(sudo ros engine enable invalid 2>&1 || true) | grep "invalid is not a valid engine"
+
 docker run -d --restart=always nginx
 docker ps | grep nginx`)
 


### PR DESCRIPTION
If `index.yml` is updated to include an additional item, it'll be be flagged as invalid since `index.yml` is currently cached.

Supersedes #1074 

#1074 
#1080 
#1154