### PR TITLE
Set rancher.environment.KERNEL_VERSION from /proc/version

### DIFF
--- a/docker/env.go
+++ b/docker/env.go
@@ -2,10 +2,13 @@ package docker
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	composeConfig "github.com/docker/libcompose/config"
 	"github.com/rancher/os/config"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type ConfigEnvironment struct {
@@ -40,6 +43,12 @@ func environmentFromCloudConfig(cfg *config.CloudConfig) map[string]string {
 	if cfg.Rancher.Network.NoProxy != "" {
 		environment["no_proxy"] = cfg.Rancher.Network.NoProxy
 		environment["NO_PROXY"] = cfg.Rancher.Network.NoProxy
+	}
+	b, err := ioutil.ReadFile("/proc/version")
+	if err == nil {
+		elem := strings.Split(string(b), " ")
+		environment["KERNEL_VERSION"] = elem[2]
+		log.Debugf("Using /proc/version to set rancher.environment.KERNEL_VERSION = %s", elem[2])
 	}
 	return environment
 }

--- a/tests/assets/test_22/cloud-config.yml
+++ b/tests/assets/test_22/cloud-config.yml
@@ -1,6 +1,6 @@
 #cloud-config
 rancher:
   services_include:
-    kernel-headers-4.8.10-rancher: true
+    kernel-headers: true
 ssh_authorized_keys:
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/kernel_headers_test.go
+++ b/tests/kernel_headers_test.go
@@ -7,5 +7,5 @@ func (s *QemuSuite) TestKernelHeaders(c *C) {
 
 	s.CheckCall(c, `
 sleep 15
-docker inspect kernel-headers-$(uname -r)`)
+docker inspect kernel-headers`)
 }


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

goes with https://github.com/rancher/os-services/pull/66

the only thing that bothers me, is that these env vars are not visible when running `ros config export -f`

resolves #1419