### PR TITLE
WIP: Recovery console

### DIFF
--- a/cmd/control/cli.go
+++ b/cmd/control/cli.go
@@ -101,6 +101,13 @@ func Main() {
 			Action:          preloadImagesAction,
 		},
 		{
+			Name:            "recovery-init",
+			Hidden:          true,
+			HideHelp:        true,
+			SkipFlagParsing: true,
+			Action:          recoveryInitAction,
+		},
+		{
 			Name:            "switch-console",
 			Hidden:          true,
 			HideHelp:        true,

--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -67,7 +67,7 @@ func consoleInitAction(c *cli.Context) error {
 		log.Error(err)
 	}
 
-	if err := writeRespawn(); err != nil {
+	if err := writeRespawn("rancher", true); err != nil {
 		log.Error(err)
 	}
 
@@ -129,7 +129,7 @@ func consoleInitAction(c *cli.Context) error {
 	return syscall.Exec(respawnBinPath, []string{"respawn", "-f", "/etc/respawn.conf"}, os.Environ())
 }
 
-func generateRespawnConf(cmdline string) string {
+func generateRespawnConf(cmdline, user string, sshd bool) string {
 	var respawnConf bytes.Buffer
 
 	for i := 1; i < 7; i++ {
@@ -137,7 +137,7 @@ func generateRespawnConf(cmdline string) string {
 
 		respawnConf.WriteString(gettyCmd)
 		if strings.Contains(cmdline, fmt.Sprintf("rancher.autologin=%s", tty)) {
-			respawnConf.WriteString(" --autologin rancher")
+			respawnConf.WriteString(fmt.Sprintf(" --autologin %s", user))
 		}
 		respawnConf.WriteString(fmt.Sprintf(" 115200 %s\n", tty))
 	}
@@ -149,23 +149,25 @@ func generateRespawnConf(cmdline string) string {
 
 		respawnConf.WriteString(gettyCmd)
 		if strings.Contains(cmdline, fmt.Sprintf("rancher.autologin=%s", tty)) {
-			respawnConf.WriteString(" --autologin rancher")
+			respawnConf.WriteString(fmt.Sprintf(" --autologin %s", user))
 		}
 		respawnConf.WriteString(fmt.Sprintf(" 115200 %s\n", tty))
 	}
 
-	respawnConf.WriteString("/usr/sbin/sshd -D")
+	if sshd {
+		respawnConf.WriteString("/usr/sbin/sshd -D")
+	}
 
 	return respawnConf.String()
 }
 
-func writeRespawn() error {
+func writeRespawn(user string, sshd bool) error {
 	cmdline, err := ioutil.ReadFile("/proc/cmdline")
 	if err != nil {
 		return err
 	}
 
-	respawn := generateRespawnConf(string(cmdline))
+	respawn := generateRespawnConf(string(cmdline), user, sshd)
 
 	files, err := ioutil.ReadDir("/etc/respawn.conf.d")
 	if err == nil {

--- a/cmd/control/recovery_init.go
+++ b/cmd/control/recovery_init.go
@@ -1,0 +1,25 @@
+package control
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+func recoveryInitAction(c *cli.Context) error {
+	if err := writeRespawn("root", false); err != nil {
+		log.Error(err)
+	}
+
+	os.Setenv("TERM", "linux")
+
+	respawnBinPath, err := exec.LookPath("respawn")
+	if err != nil {
+		return err
+	}
+
+	return syscall.Exec(respawnBinPath, []string{"respawn", "-f", "/etc/respawn.conf"}, os.Environ())
+}

--- a/config/schema.go
+++ b/config/schema.go
@@ -37,6 +37,7 @@ var schema = `{
         "no_sharedroot": {"type": "boolean"},
         "log": {"type": "boolean"},
         "force_console_rebuild": {"type": "boolean"},
+        "recovery": {"type": "boolean"},
         "disable": {"$ref": "#/definitions/list_of_strings"},
         "services_include": {"type": "object"},
         "modules": {"$ref": "#/definitions/list_of_strings"},

--- a/config/types.go
+++ b/config/types.go
@@ -110,6 +110,7 @@ type RancherConfig struct {
 	NoSharedRoot        bool                                      `yaml:"no_sharedroot,omitempty"`
 	Log                 bool                                      `yaml:"log,omitempty"`
 	ForceConsoleRebuild bool                                      `yaml:"force_console_rebuild,omitempty"`
+	Recovery            bool                                      `yaml:"recovery,omitempty"`
 	Disable             []string                                  `yaml:"disable,omitempty"`
 	ServicesInclude     map[string]bool                           `yaml:"services_include,omitempty"`
 	Modules             []string                                  `yaml:"modules,omitempty"`

--- a/init/init.go
+++ b/init/init.go
@@ -239,6 +239,12 @@ func RunInit() error {
 		},
 		loadModules,
 		func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
+			if cfg.Rancher.Recovery {
+				recovery(nil)
+			}
+			return cfg, nil
+		},
+		func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 			if util.ResolveDevice("LABEL=B2D_STATE") != "" {
 				boot2DockerEnvironment = true
 				cfg.Rancher.State.Dev = "LABEL=B2D_STATE"
@@ -370,7 +376,7 @@ func RunInit() error {
 
 	cfg, err := config.ChainCfgFuncs(nil, initFuncs...)
 	if err != nil {
-		return err
+		recovery(err)
 	}
 
 	launchConfig, args := getLaunchConfig(cfg, &cfg.Rancher.SystemDocker)
@@ -379,7 +385,7 @@ func RunInit() error {
 	log.Info("Launching System Docker")
 	_, err = dfs.LaunchDocker(launchConfig, config.SystemDockerBin, args...)
 	if err != nil {
-		return err
+		recovery(err)
 	}
 
 	return pidOne()

--- a/init/recovery.go
+++ b/init/recovery.go
@@ -1,0 +1,90 @@
+package init
+
+import (
+	log "github.com/Sirupsen/logrus"
+	composeConfig "github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/yaml"
+	"github.com/rancher/os/compose"
+	"github.com/rancher/os/config"
+)
+
+var (
+	recoveryDockerService = composeConfig.ServiceConfigV1{
+		Image: config.OsBase,
+		Command: yaml.Command{
+			"ros",
+			"recovery-init",
+		},
+		Labels: map[string]string{
+			config.DetachLabel: "false",
+			config.ScopeLabel:  "system",
+		},
+		LogDriver:  "json-file",
+		Net:        "host",
+		Uts:        "host",
+		Pid:        "host",
+		Ipc:        "host",
+		Privileged: true,
+		Volumes: []string{
+			"/dev:/host/dev",
+			"/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher",
+			"/lib/modules:/lib/modules",
+			"/lib/firmware:/lib/firmware",
+			"/usr/bin/ros:/usr/bin/ros:ro",
+			"/usr/bin/ros:/usr/bin/cloud-init-save",
+			"/usr/bin/ros:/usr/bin/respawn:ro",
+			"/usr/share/ros:/usr/share/ros:ro",
+			"/var/lib/rancher:/var/lib/rancher",
+			"/var/lib/rancher/conf:/var/lib/rancher/conf",
+		},
+	}
+)
+
+func recoveryServices(cfg *config.CloudConfig) (*config.CloudConfig, error) {
+	_, err := compose.RunServiceSet("recovery", cfg, map[string]*composeConfig.ServiceConfigV1{
+		"recovery": &recoveryDockerService,
+	})
+	return nil, err
+}
+
+func recovery(initFailure error) {
+	if initFailure != nil {
+		log.Errorf("RancherOS has failed to boot: %v", initFailure)
+	}
+	log.Info("Launching recovery console")
+
+	var recoveryConfig config.CloudConfig
+	recoveryConfig.Rancher.Defaults = config.Defaults{
+		Network: config.NetworkConfig{
+			DNS: config.DNSConfig{
+				Nameservers: []string{
+					"8.8.8.8",
+					"8.8.4.4",
+				},
+			},
+		},
+	}
+	recoveryConfig.Rancher.BootstrapDocker = config.DockerConfig{
+		EngineOpts: config.EngineOpts{
+			Bridge:        "none",
+			StorageDriver: "overlay",
+			Restart:       &[]bool{false}[0],
+			Graph:         "/var/lib/recovery-docker",
+			Group:         "root",
+			Host:          []string{"unix:///var/run/system-docker.sock"},
+			UserlandProxy: &[]bool{false}[0],
+		},
+	}
+
+	_, err := startDocker(&recoveryConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = config.ChainCfgFuncs(&recoveryConfig,
+		loadImages,
+		recoveryServices)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -35,6 +35,7 @@
         "no_sharedroot": {"type": "boolean"},
         "log": {"type": "boolean"},
         "force_console_rebuild": {"type": "boolean"},
+        "recovery": {"type": "boolean"},
         "disable": {"$ref": "#/definitions/list_of_strings"},
         "services_include": {"type": "object"},
         "modules": {"$ref": "#/definitions/list_of_strings"},


### PR DESCRIPTION
Mainly opening this to begin some discussion around design for #140. The original issue is a little vague, so it's worth thinking about what a recovery console would actually be used for. This PR handles these two cases.

1. Graceful handling of boot failures. In most scenarios we just we return an error in the init process, which leads to a kernel panic. This makes it so we print an error and drop into a recovery console instead.
The console itself is just a really minimal subset of the standard console. Something similar to Bootstrap Docker is still required to start the recovery console. It's designed to not require any reading of configuration, which means it should start successfully regardless of any errors in configuration. This results in a bit of hard coding, but I think it's worth it since this is a pretty important use case.

2. Purposely booting into the recovery console. The recovery console can also be manually used by setting the `rancher.recovery` kernel parameter. This could be useful for performing manual disk operations that can only be done when the disk isn't mounted.