### PR TITLE
Load modules after running PrepareFs

### DIFF
--- a/init/init.go
+++ b/init/init.go
@@ -59,7 +59,10 @@ func loadModules(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 		}
 
 		log.Debugf("Loading module %s", module)
-		if err := exec.Command("modprobe", module).Run(); err != nil {
+		cmd := exec.Command("modprobe", module)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
 			log.Errorf("Could not load module %s, err %v", module, err)
 		}
 	}

--- a/init/init.go
+++ b/init/init.go
@@ -359,10 +359,10 @@ func RunInit() error {
 
 			return config.LoadConfig(), nil
 		},
-		loadModules,
 		func(c *config.CloudConfig) (*config.CloudConfig, error) {
 			return c, dfs.PrepareFs(&mountConfig)
 		},
+		loadModules,
 		func(c *config.CloudConfig) (*config.CloudConfig, error) {
 			network.SetProxyEnvironmentVariables(c)
 			return c, nil

--- a/tests/assets/test_27/cloud-config.yml
+++ b/tests/assets/test_27/cloud-config.yml
@@ -1,0 +1,5 @@
+#cloud-config
+rancher:
+  modules: [btrfs]
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/modules_test.go
+++ b/tests/modules_test.go
@@ -1,0 +1,13 @@
+package integration
+
+import . "gopkg.in/check.v1"
+
+func (s *QemuSuite) TestKernelParameterModule(c *C) {
+	s.RunQemu(c, "--append", "rancher.modules=[btrfs]")
+	s.CheckCall(c, "lsmod | grep btrfs")
+}
+
+func (s *QemuSuite) TestCloudConfigModule(c *C) {
+	s.RunQemu(c, "--cloud-config", "./tests/assets/test_27/cloud-config.yml")
+	s.CheckCall(c, "lsmod | grep btrfs")
+}


### PR DESCRIPTION
Early cloud-init exposed a bug that previously existed with module loading. The second call to `loadModules` should be run after `dfs.PrepareFs`. Before early cloud-init, the second call to `loadModules` was never actually used.

#1353 