### PR TITLE
WIP: Use strato as os-base base image

### DIFF
--- a/images/00-rootfs/.dockerignore
+++ b/images/00-rootfs/.dockerignore
@@ -1,2 +1,0 @@
-assets
-build/dist/kernel

--- a/images/00-rootfs/Dockerfile
+++ b/images/00-rootfs/Dockerfile
@@ -1,2 +1,0 @@
-FROM scratch
-ADD build/rootfs.tar /

--- a/images/00-rootfs/prebuild.sh
+++ b/images/00-rootfs/prebuild.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-TAR=${DOWNLOADS}/rootfs.tar
-
-if [ -e $TAR ]; then
-    cd $(dirname $0)
-    mkdir -p build
-    cp $TAR build
-fi

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -1,16 +1,16 @@
-FROM strato-min
-# FROM amd64=stratopkg/strato-min:0.0.1 arm64=stratopkg/strato-min:0.0.1_arm64 arm=skip
+FROM joshwget/strato-min:0.0.2
+# FROM amd64=joshwget/strato-min:0.0.2 arm64=joshwget/strato-min:0.0.2_arm64 arm=skip
 
-RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0.0.1/strato_$(get-arch)" \
+RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0.0.2/strato_$(get-arch)" \
     && chmod +x /sbin/strato \
-    && strato add bash \
+    && strato --source="https://github.com/joshwget/strato-packages/raw/master/0.0.2/$(get-arch)/" add bash \
     openssh \
     zlib \
     e2fsprogs \
-    util-linux#agetty \
-    util-linux#partx \
-    util-linux#libuuid \
-    util-linux#libblkid \
+    agetty \
+    partx \
+    libuuid \
+    libblkid \
     kmod \
     xz \
     iproute2 \

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -1,43 +1,50 @@
-FROM rancher/os-rootfs
-RUN ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
-# Cleanup Buildroot
-RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
-    sed -i '/^root/s!/bin/sh!/bin/bash!' /etc/passwd && \
-    echo 'RancherOS \n \l' > /etc/issue && \
-    rm -rf /run \
-       /linuxrc \
-       /etc/os-release \
-       /var/cache \
-       /var/lock \
-       /var/log \
-       /var/run \
-       /var/spool \
-       /var/lib/misc && \
-    mkdir -p \
-       /home \
-       /run \
-       /var/cache \
-       /var/lock \
-       /var/log \
-       /var/run \
-       /var/spool && \
-    passwd -l root && \
-    addgroup -g 1100 rancher && \
+FROM stratopkg/strato-min:0.0.1
+RUN wget -P /sbin https://github.com/joshwget/strato/releases/download/0.0.1/strato \
+    && chmod +x /sbin/strato \
+    && strato add bash \
+    openssh \
+    zlib \
+    e2fsprogs \
+    util-linux%agetty \
+    util-linux%partx \
+    util-linux%libuuid \
+    util-linux%libblkid \
+    kmod \
+    xz \
+    iproute2 \
+    dhcpcd \
+    eudev \
+    jq \
+    acpi \
+    rsync \
+    libestr \
+    json-c \
+    rsyslog \
+    sudo \
+    parted \
+    ntp \
+    && rm /sbin/strato
+
+RUN mkdir -p /etc/acpi
+RUN rm -rf /etc/ssh/*key*
+
+RUN addgroup -g 1100 rancher && \
     addgroup -g 1101 docker && \
     addgroup -g 1103 sudo && \
     adduser -u 1100 -G rancher -D -h /home/rancher -s /bin/bash rancher && \
     adduser -u 1101 -G docker -D -h /home/docker -s /bin/bash docker && \
     adduser rancher docker && \
     adduser rancher sudo && \
+    adduser rancher input && \
     adduser docker sudo && \
+    adduser docker input && \
     echo '%sudo ALL=(ALL) ALL' >> /etc/sudoers
+
 COPY inputrc /etc/inputrc
 COPY growpart /usr/bin/growpart
+
+# TODO: rebase this properly
 RUN sed -i s/"partx --update \"\$part\" \"\$dev\""/"partx --update --nr \"\$part\" \"\$dev\""/g /usr/bin/growpart && \
-    sed -i -e 's/duid/clientid/g' /etc/dhcpcd.conf && \
-    sed -i 1,10d /etc/rsyslog.conf && \
-    echo "*.*                /var/log/syslog" >> /etc/rsyslog.conf
-# dump kernel log to console (but after we've finished booting)
-#    echo "kern.*                /dev/console" >> /etc/rsyslog.conf
+    sed -i -e 's/duid/clientid/g' /etc/dhcpcd.conf
 
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -1,5 +1,7 @@
-FROM stratopkg/strato-min:0.0.1
-RUN wget -P /sbin https://github.com/joshwget/strato/releases/download/0.0.1/strato \
+FROM strato-min
+# FROM amd64=stratopkg/strato-min:0.0.1 arm64=stratopkg/strato-min:0.0.1_arm64 arm=skip
+
+RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0.0.1/strato_$(get-arch)" \
     && chmod +x /sbin/strato \
     && strato add bash \
     openssh \

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -29,6 +29,8 @@ RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0
 
 RUN mkdir -p /etc/acpi
 RUN rm -rf /etc/ssh/*key*
+RUN sed -i s/"\/bin\/ash"/"\/bin\/bash"/g /etc/passwd \
+    && rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN addgroup -g 1100 rancher && \
     addgroup -g 1101 docker && \

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -7,10 +7,10 @@ RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0
     openssh \
     zlib \
     e2fsprogs \
-    util-linux%agetty \
-    util-linux%partx \
-    util-linux%libuuid \
-    util-linux%libblkid \
+    util-linux#agetty \
+    util-linux#partx \
+    util-linux#libuuid \
+    util-linux#libblkid \
     kmod \
     xz \
     iproute2 \

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -25,6 +25,7 @@ RUN wget -O /sbin/strato "https://github.com/joshwget/strato/releases/download/0
     sudo \
     parted \
     ntp \
+    iptables \
     && rm /sbin/strato
 
 RUN mkdir -p /etc/acpi

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -78,7 +78,7 @@ rancher:
     {{if eq "amd64" .ARCH -}}
     acpid:
       image: {{.OS_REPO}}/os-acpid:{{.VERSION}}{{.SUFFIX}}
-      command: /usr/sbin/acpid -f
+      command: acpid -f
       labels:
         io.rancher.os.scope: system
       net: host

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -11,6 +11,8 @@ mkdir -p dist
 rm -f dist/images
 touch dist/images
 
+docker rmi stratopkg/strato-min:0.0.1
+
 for i in $BASE/[0-9]*; do
     name="os-$(echo ${i} | cut -f2 -d-)"
     tag="${OS_REPO}/${name}:${VERSION}${SUFFIX}"

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -11,8 +11,6 @@ mkdir -p dist
 rm -f dist/images
 touch dist/images
 
-docker rmi stratopkg/strato-min:0.0.1
-
 for i in $BASE/[0-9]*; do
     name="os-$(echo ${i} | cut -f2 -d-)"
     tag="${OS_REPO}/${name}:${VERSION}${SUFFIX}"


### PR DESCRIPTION
[strato](https://github.com/joshwget/strato) is a small image based on glibc with a containerized build process for packages.

Using `strato-min` rather than `strato` as the base image for now. The only difference is that `strato-min` doesn't actually include the strato binary. It's fairly large and doesn't add much value to the base image for now.

This increases ISO size by about 2mb, but I think most of this is a result of switching from uclibc to glibc. It's likely that a lot of optimizations can be made still.

The only work remaining is testing and multiarch support. I'm nearly done with the arm64 port of strato and I don't expect the arm port to be much work beyond that.