### PR TITLE
WIP: Simplify list syntax for kernel paramaters and 'ros config set'

### DIFF
--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -147,14 +147,24 @@ func env2map(env []string) map[string]string {
 }
 
 func configSet(c *cli.Context) error {
+
 	key := c.Args().Get(0)
-	value := c.Args().Get(1)
 	if key == "" {
 		return nil
 	}
 
-	err := config.Set(key, value)
-	if err != nil {
+	var value interface{}
+	if len(c.Args()) == 2 {
+		value = c.Args().Get(1)
+	} else if len(c.Args()) > 2 {
+		values := []interface{}{}
+		for _, arg := range c.Args()[1:] {
+			values = append(values, arg)
+		}
+		value = values
+	}
+
+	if err := config.Set(key, value); err != nil {
 		log.Fatal(err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/rancher/os/util"
 )
@@ -45,13 +47,38 @@ func GetCmdline(key string) interface{} {
 	return v
 }
 
+// TOOO: value should be able to be an array here
 func Set(key string, value interface{}) error {
+	modified := checkTypeAndSetVal(key, map[interface{}]interface{}{}, value)
+	//_, modified := getOrSetVal(key, map[interface{}]interface{}{}, value)
+
+	fmt.Println("@!", modified)
+
 	existing, err := readConfigs(nil, false, true, CloudConfigFile)
 	if err != nil {
 		return err
 	}
 
-	_, modified := getOrSetVal(key, existing, value)
+	modified = util.Merge(existing, modified)
+
+	fmt.Println("##", modified)
+
+	c := &CloudConfig{}
+	if err = util.Convert(modified, c); err != nil {
+		return err
+	}
+
+	return WriteToFile(modified, CloudConfigFile)
+}
+
+func FastSet(key string, value interface{}) error {
+	existing, err := readConfigs(nil, false, true, CloudConfigFile)
+	if err != nil {
+		return err
+	}
+
+	//_, modified := getOrSetVal(key, existing, value)
+	modified := checkTypeAndSetVal(key, existing, value)
 
 	c := &CloudConfig{}
 	if err = util.Convert(modified, c); err != nil {

--- a/config/yaml/command.go
+++ b/config/yaml/command.go
@@ -27,6 +27,14 @@ func (s *StringandSlice) UnmarshalYAML(tag string, value interface{}) error {
 	return nil
 }
 
+/*func (s *StringandSlice) MarshalYAML() (interface{}, error) {
+	ulimitMap := make(map[string]Ulimit)
+	for _, ulimit := range u.Elements {
+		ulimitMap[ulimit.Name] = ulimit
+	}
+	return ulimitMap, nil
+}*/
+
 // TODO: use this function from libcompose
 func toStrings(s []interface{}) ([]string, error) {
 	if len(s) == 0 {

--- a/init/init.go
+++ b/init/init.go
@@ -280,6 +280,7 @@ func RunInit() error {
 			}
 
 			cfg.Rancher.CloudInit.Datasources = config.LoadConfigWithPrefix(state).Rancher.CloudInit.Datasources
+			fmt.Println("1", cfg.Rancher.CloudInit.Datasources)
 			if err := config.Set("rancher.cloud_init.datasources", cfg.Rancher.CloudInit.Datasources); err != nil {
 				log.Error(err)
 			}
@@ -346,9 +347,11 @@ func RunInit() error {
 		},
 		func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 			if boot2DockerEnvironment {
+				fmt.Println("2", cfg.Rancher.State.Dev)
 				if err := config.Set("rancher.state.dev", cfg.Rancher.State.Dev); err != nil {
 					log.Errorf("Failed to update rancher.state.dev: %v", err)
 				}
+				fmt.Println("3", cfg.Rancher.State.Autoformat)
 				if err := config.Set("rancher.state.autoformat", cfg.Rancher.State.Autoformat); err != nil {
 					log.Errorf("Failed to update rancher.state.autoformat: %v", err)
 				}

--- a/tests/ros_config_test.go
+++ b/tests/ros_config_test.go
@@ -53,7 +53,7 @@ fi`)
 	s.CheckCall(c, `
 set -x -e
 
-sudo ros config set rancher.network.dns.search '[a,b]'
+sudo ros config set rancher.network.dns.search a b
 if [ "$(sudo ros config get rancher.network.dns.search)" == "- a
  - b
 
@@ -62,12 +62,12 @@ if [ "$(sudo ros config get rancher.network.dns.search)" == "- a
     exit 1
  fi
 
-sudo ros config set rancher.network.dns.search '[]'
-if [ "$(sudo ros config get rancher.network.dns.search)" == "[]
- " ]; then
-    sudo ros config get rancher.network.dns.search
-    exit 1
- fi`)
+#sudo ros config set rancher.network.dns.search '[]'
+#if [ "$(sudo ros config get rancher.network.dns.search)" == "[]
+# " ]; then
+#    sudo ros config get rancher.network.dns.search
+#    exit 1
+# fi`)
 
 	s.CheckCall(c, `
 set -x -e


### PR DESCRIPTION
Switch to the syntax described in #1494. The existing format is backward compatible for kernel parameters but not when used with `ros config set`.

Other than testing and docs the big thing remaining is to speed up the parsing. A bit of reflection is needed to make the new syntax possible and it's called pretty often. It actually causes a delay that can be noticed when the console starts. Adding caching to the `getFieldType` function should fix this problem.