### PR TITLE
Add config option to disable sshd

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -144,7 +144,8 @@ var schema = `{
       "additionalProperties": false,
 
       "properties": {
-        "keys": {"type": "object"}
+        "keys": {"type": "object"},
+        "disable": {"type": "boolean"}
       }
     },
 

--- a/config/types.go
+++ b/config/types.go
@@ -204,7 +204,8 @@ type DNSConfig struct {
 }
 
 type SSHConfig struct {
-	Keys map[string]string `yaml:"keys,omitempty"`
+	Keys    map[string]string `yaml:"keys,omitempty"`
+	Disable bool              `yaml:"disable,omitempty"`
 }
 
 type StateConfig struct {

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -142,7 +142,8 @@
       "additionalProperties": false,
 
       "properties": {
-        "keys": {"type": "object"}
+        "keys": {"type": "object"},
+        "disable": {"type": "boolean"}
       }
     },
 


### PR DESCRIPTION
If you have access to the Docker socket for a host or if you're running an agent for an orchestration system you may not need sshd running. There should be a pretty simple option available to disable this in the console.