### PR TITLE
Revert "4.9.3"

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -55,8 +55,7 @@ ARG DOCKER_BUILD_VERSION=1.10.3
 ARG DOCKER_BUILD_PATCH_VERSION=v${DOCKER_BUILD_VERSION}-ros1
 ARG SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.3/policy.29
 
-#ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v4.8.17-rancher/linux-4.8.17-rancher-x86.tar.gz
-ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v4.9.3-rancher/linux-4.9.3-rancher-x86.tar.gz
+ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v4.9-rancher2/linux-4.9-rancher2-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/imikushin/os-kernel/releases/download/Estuary-4.4.0-arm64.8/linux-4.4.0-rancher-arm64.tar.gz
 
 ARG DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz
@@ -73,9 +72,9 @@ ARG OS_SERVICES_REPO=https://raw.githubusercontent.com/${OS_REPO}/os-services
 ARG IMAGE_NAME=${OS_REPO}/os
 ARG DFS_IMAGE=${OS_REPO}/docker:v${DOCKER_VERSION}-2
 
-ARG OS_BASE_URL_amd64=https://github.com/rancher/os-base/releases/download/v2016.11.1-1/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2016.11.1-1/os-base_arm64.tar.xz
-ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2016.11.1-1/os-base_arm.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/rancher/os-base/releases/download/v2016.08.1-2/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2016.08.1-2/os-base_arm64.tar.xz
+ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2016.08.1-2/os-base_arm.tar.xz
 ######################################################
 
 # Set up environment and export all ARGS as ENV

--- a/scripts/run
+++ b/scripts/run
@@ -5,7 +5,6 @@ set -e
 cd $(dirname $0)/..
 
 source ./scripts/run-common
-MEMORY=2048
 
 while [ "$#" -gt 0 ]; do
     case $1 in
@@ -32,10 +31,6 @@ while [ "$#" -gt 0 ]; do
             ;;
         --second-drive)
             SECOND_DRIVE=1
-            ;;
-        --memory)
-            shift 1
-            MEMORY="$1"
             ;;
         --arch)
             shift 1
@@ -75,7 +70,6 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$QEMU" == "1" ] && ! which qemu-system-${QEMUARCH}; then
-    echo "ERROR: qemu not found - do you need to install it?"
     QEMU=0
 fi
 
@@ -160,7 +154,7 @@ if [ "$QEMU" == "1" ]; then
             ${KVM_ENABLE} \
             ${CPU} \
             ${machine["$ARCH"]} \
-            -m $MEMORY \
+            -m 2048 \
             ${network["$ARCH"]} \
             $(eval "${hd["$ARCH"]} ${HD}") \
             ${SECOND_DRIVE_ENABLE} \
@@ -182,7 +176,7 @@ elif [ "$BOOT_ISO" == "1" ]; then
             ${KVM_ENABLE} \
             ${CPU} \
             ${machine["$ARCH"]} \
-            -m $MEMORY \
+            -m 2048 \
             ${network["$ARCH"]} \
             $(eval "${hd["$ARCH"]} ${HD}") \
             ${SECOND_DRIVE_ENABLE} \


### PR DESCRIPTION
Reverts rancher/os#1510

yes, it looks like updating to buildroot 2016.11 breaks the dhcp hostname support - and there's a test that fails. 