### PR TITLE
Didn't see it - qemu doesn't complain, it only fails in iso boot mode…

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -227,7 +227,7 @@ elif [ "$BOOT_ISO" == "1" ] ||
             ${KVM_ENABLE} \
             ${CPU} \
             ${machine["$ARCH"]} \
-            -m MEMORY \
+            -m $MEMORY \
             ${network["$ARCH"]} \
             $(eval "${hd["$ARCH"]} ${HD}") \
             ${SECOND_DRIVE_ENABLE} \


### PR DESCRIPTION
… during loading the initrd

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

closes #1554