### PR TITLE
Restore missing initrd artifact.

### DIFF
--- a/scripts/package-initrd
+++ b/scripts/package-initrd
@@ -3,11 +3,11 @@ set -e
 
 cd $(dirname $0)/..
 
-source scripts/version
-
 BUILD=$(pwd)/build
 INITRD_DIR=${BUILD}/initrd
 ARTIFACTS=$(pwd)/dist/artifacts
+
+source scripts/version
 
 mkdir -p ${ARTIFACTS}
 

--- a/scripts/package-installer
+++ b/scripts/package-installer
@@ -3,7 +3,11 @@ set -e
 
 cd $(dirname $0)/..
 
-source ./scripts/version
+BUILD=$(pwd)/build
+INITRD_DIR=${BUILD}/initrd
+ARTIFACTS=$(pwd)/dist/artifacts
+
+source scripts/version
 
 BASEDOCKERFILE=./scripts/installer/BaseDockerfile.${ARCH}
 DOCKERFILE=./scripts/installer/Dockerfile.${ARCH}

--- a/scripts/package-iso
+++ b/scripts/package-iso
@@ -2,13 +2,14 @@
 set -e
 set -x
 
-source $(dirname $0)/version
 cd $(dirname $0)/..
 
 ARTIFACTS=$(pwd)/dist/artifacts
 CD=${BUILD}/cd
 ISO=${ARTIFACTS}/$(echo ${DISTRIB_ID} | tr '[:upper:]' '[:lower:]').iso
 CHECKSUM=iso-checksums.txt
+
+source scripts/version
 
 mkdir -p ${CD}/boot/isolinux
 mkdir -p ${CD}/rancheros

--- a/scripts/package-rootfs
+++ b/scripts/package-rootfs
@@ -4,14 +4,13 @@ set -o pipefail
 
 cd $(dirname $0)/..
 
-source scripts/version
-
 BUILD=$(pwd)/build
 IMAGE_CACHE=${BUILD}/image-cache
 PREPOP_DIR=${IMAGE_CACHE}/var/lib/system-docker
 INITRD_DIR=${BUILD}/initrd
 ARTIFACTS=$(pwd)/dist/artifacts
-INITRD=${ARTIFACTS}/initrd
+
+source scripts/version
 
 mkdir -p ${ARTIFACTS} ${PREPOP_DIR}
 


### PR DESCRIPTION
The initrd has been built but not dropped into dist/artifacts since b3a9893. This is because scripts/version depends on ARTIFACTS being defined, but in most cases was sourced before that happened.