### PR TITLE
Looks like /sys/fs/selinux should be mounted ro

### DIFF
--- a/dfs/scratch.go
+++ b/dfs/scratch.go
@@ -38,7 +38,7 @@ var (
 		{"none", "/sys/fs/cgroup", "tmpfs", ""},
 	}
 	optionalMounts = [][]string{
-		{"none", "/sys/fs/selinux", "selinuxfs", ""},
+		{"none", "/sys/fs/selinux", "selinuxfs", "ro"},
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

fix for #1624