### PR TITLE
Count number of args for ros config set command

### DIFF
--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -147,6 +147,10 @@ func env2map(env []string) map[string]string {
 }
 
 func configSet(c *cli.Context) error {
+	if c.NArg() < 2 {
+		return nil
+	}
+
 	key := c.Args().Get(0)
 	value := c.Args().Get(1)
 	if key == "" {


### PR DESCRIPTION
This is related to #1621

`ros config set rancher.debug=true`, `rancher.debug=true` is being seen as one arg when two args are expected like `rancher.debug true`

The condition added make sure that 2 args are being passed.