### PR TITLE
Don't complain if there is no cloud-config supplied when upgrading

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -196,7 +196,7 @@ func osVersion(c *cli.Context) error {
 
 func startUpgradeContainer(image string, stage, force, reboot, kexec bool, upgradeConsole bool, kernelArgs string) error {
 	command := []string{
-		"-t", "rancher-upgrade",
+		"-t", "upgrade",
 		"-r", config.Version,
 	}
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

and remove `rancher-upgrade` as a synonym for `upgrade` in the code

this is for #1610