### PR TITLE
Remove DHCP addresses from devices that change to static

### DIFF
--- a/cmd/control/install.go
+++ b/cmd/control/install.go
@@ -354,7 +354,7 @@ func mountBootIso() error {
 
 	os.MkdirAll("/bootiso", 0755)
 	cmd := exec.Command("mount", "-t", deviceType, deviceName, "/bootiso")
-	log.Infof("mount (%#v)", cmd)
+	log.Debugf("mount (%#v)", cmd)
 
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	err = cmd.Run()

--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -11,7 +11,6 @@ import (
 
 func Main() {
 	log.InitLogger()
-	log.Infof("Running network")
 
 	cfg := config.LoadConfig()
 	ApplyNetworkConfig(cfg)
@@ -20,6 +19,7 @@ func Main() {
 }
 
 func ApplyNetworkConfig(cfg *config.CloudConfig) {
+	log.Infof("Apply Network Config")
 	nameservers := cfg.Rancher.Network.DNS.Nameservers
 	search := cfg.Rancher.Network.DNS.Search
 	userSetDNS := len(nameservers) > 0 || len(search) > 0

--- a/init/init.go
+++ b/init/init.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 
 	"github.com/docker/docker/pkg/mount"
+	"github.com/rancher/os/cmd/control"
+	//networkCmd "github.com/rancher/os/cmd/network"
 	"github.com/rancher/os/config"
 	"github.com/rancher/os/dfs"
 	"github.com/rancher/os/log"
@@ -302,6 +304,11 @@ func RunInit() error {
 				log.Error(err)
 			}
 
+			if err := control.UdevSettle(); err != nil {
+				log.Errorf("Failed to run udev settle: %v", err)
+			}
+
+			log.Debug("init: runCloudInitServices()")
 			if err := runCloudInitServices(cfg); err != nil {
 				log.Error(err)
 			}

--- a/tests/assets/multi_nic/cloud-config.yml
+++ b/tests/assets/multi_nic/cloud-config.yml
@@ -3,11 +3,13 @@ rancher:
   network:
     interfaces:
       eth0:
+        dhcp: true
+      eth1:
         address: 10.1.0.41/24
         gateway: 10.1.0.1
         mtu: 1500
         dhcp: false
-      eth1:
+      eth2:
         address: 10.31.168.85/24
         gateway: 10.31.168.1
         gateway_ipv6: "fe00:1234::"

--- a/tests/network_from_url_test.go
+++ b/tests/network_from_url_test.go
@@ -4,7 +4,7 @@ import . "gopkg.in/check.v1"
 
 func (s *QemuSuite) TestNetworkFromUrl(c *C) {
 	netArgs := []string{"-net", "nic,vlan=0,model=virtio"}
-	args := []string{"--append", "rancher.cloud_init.datasources=[url:https://gist.githubusercontent.com/joshwget/0bdc616cd26162ad87c535644c8b1ef6/raw/8cce947c08cf006e932b71d92ddbb96bae8e3325/gistfile1.txt]"}
+	args := []string{"--append", "rancher.debug=true rancher.password=test-me rancher.cloud_init.datasources=[url:https://gist.githubusercontent.com/joshwget/0bdc616cd26162ad87c535644c8b1ef6/raw/8cce947c08cf006e932b71d92ddbb96bae8e3325/gistfile1.txt]"}
 	for i := 0; i < 7; i++ {
 		args = append(args, netArgs...)
 	}

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -36,6 +36,107 @@ SCRIPT
 sudo bash test-merge`)
 }
 
+func (s *QemuSuite) TestNetworkBootCfg(c *C) {
+	args := []string{"--append", "rancher.network.interfaces.eth1.address=10.1.0.41/24 rancher.network.interfaces.eth1.gateway=10.1.0.1 rancher.network.interfaces.eth0.dhcp=true"}
+	args = append(args, []string{"-net", "nic,vlan=1,model=virtio"}...)
+	args = append(args, []string{"-net", "nic,vlan=1,model=virtio"}...)
+	args = append(args, []string{"-net", "nic,vlan=0,model=virtio"}...)
+	s.RunQemu(c, args...)
+	s.CheckOutput(c,
+		"1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1\n"+
+			"    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00\n"+
+			"    inet 127.0.0.1/8 scope host lo\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 ::1/128 scope host \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth0\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3456/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet 10.1.0.41/24 scope global eth1\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3457/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000\n"+
+			"5: eth3: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000\n"+
+			"6: docker-sys: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000\n"+
+			"    inet 172.18.42.2/16 scope global docker-sys\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 XX::XX:XX:XX:XX/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"8: docker0: XXXXXXX......\n"+
+			"    inet 172.17.0.1/16 scope global docker0\n"+
+			"       valid_lft forever preferred_lft forever\n",
+		Equals,
+		"ip a | "+
+			"grep -v ether | "+
+			"sed 's/inet 10\\.0\\.2\\..*\\/24 brd/inet XX.XX.XX.XX\\/24 brd/' | "+
+			"sed 's/8: docker0: .*/8: docker0: XXXXXXX....../g' | "+
+			"sed '/inet6 fe80::5054:ff:fe12:.*\\/64/!s/inet6 .*\\/64 scope/inet6 XX::XX:XX:XX:XX\\/64 scope/'",
+		// fe80::18b6:9ff:fef5:be33
+	)
+}
+
+func (s *QemuSuite) TestNetworkBootAndCloudCfg(c *C) {
+	args := []string{
+		"--append", "rancher.network.interfaces.eth1.address=10.1.0.52/24 rancher.network.interfaces.eth1.gateway=10.1.0.1 rancher.network.interfaces.eth0.dhcp=true rancher.network.interfaces.eth3.dhcp=true",
+		"--cloud-config", "./tests/assets/multi_nic/cloud-config.yml",
+	}
+	args = append(args, []string{"-net", "nic,vlan=1,model=virtio"}...)
+	args = append(args, []string{"-net", "nic,vlan=1,model=virtio"}...)
+	args = append(args, []string{"-net", "nic,vlan=0,model=virtio"}...)
+	s.RunQemu(c, args...)
+	s.CheckOutput(c,
+		"1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1\n"+
+			"    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00\n"+
+			"    inet 127.0.0.1/8 scope host lo\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 ::1/128 scope host \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth0\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3456/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			// This shows that the boot cmdline wins over the cloud-config
+			// But IIRC, the cloud-init metadata wins allowing you to use ip4ll to get the hoster's metadata
+			// Need a test for that (presumably once we have libmachine based tests)
+			"    inet 10.1.0.52/24 scope global eth1\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3457/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet 10.31.168.85/24 scope global eth2\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3458/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			// TODO: I think it would be better if this was dhcp: false, but it could go either way
+			"5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth3\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3459/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"6: docker-sys: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000\n"+
+			"    inet 172.18.42.2/16 scope global docker-sys\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 XX::XX:XX:XX:XX/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"8: docker0: XXXXXXX......\n"+
+			"    inet 172.17.0.1/16 scope global docker0\n"+
+			"       valid_lft forever preferred_lft forever\n",
+		Equals,
+		"ip a | "+
+			"grep -v ether | "+
+			"sed 's/inet 10\\.0\\.2\\..*\\/24 brd/inet XX.XX.XX.XX\\/24 brd/' | "+
+			"sed 's/8: docker0: .*/8: docker0: XXXXXXX....../g' | "+
+			"sed '/inet6 fe80::5054:ff:fe12:.*\\/64/!s/inet6 .*\\/64 scope/inet6 XX::XX:XX:XX:XX\\/64 scope/'",
+		// fe80::18b6:9ff:fef5:be33
+	)
+}
+
 func (s *QemuSuite) TestNetworkCfg(c *C) {
 	args := []string{"--cloud-config", "./tests/assets/multi_nic/cloud-config.yml"}
 	args = append(args, []string{"-net", "nic,vlan=1,model=virtio"}...)
@@ -48,50 +149,78 @@ func (s *QemuSuite) TestNetworkCfg(c *C) {
 	//       valid_lft forever preferred_lft forever
 
 	// show ip a output without mac addresses
-	s.CheckOutput(c, `1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
-    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-    inet 127.0.0.1/8 scope host lo
-       valid_lft forever preferred_lft forever
-    inet6 ::1/128 scope host 
-       valid_lft forever preferred_lft forever
-2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth0
-       valid_lft forever preferred_lft forever
-    inet 10.1.0.41/24 scope global eth0
-       valid_lft forever preferred_lft forever
-    inet6 XX::XX:XX:XX:XX/64 scope link 
-       valid_lft forever preferred_lft forever
-3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-    inet 10.31.168.85/24 scope global eth1
-       valid_lft forever preferred_lft forever
-    inet6 XX::XX:XX:XX:XX/64 scope link 
-       valid_lft forever preferred_lft forever
-4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-    inet6 XX::XX:XX:XX:XX/64 scope link 
-       valid_lft forever preferred_lft forever
-5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth3
-       valid_lft forever preferred_lft forever
-    inet6 XX::XX:XX:XX:XX/64 scope link 
-       valid_lft forever preferred_lft forever
-6: docker-sys: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
-    inet 172.18.42.2/16 scope global docker-sys
-       valid_lft forever preferred_lft forever
-    inet6 XX::XX:XX:XX:XX/64 scope link 
-       valid_lft forever preferred_lft forever
-8: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
-    inet 172.17.0.1/16 scope global docker0
-       valid_lft forever preferred_lft forever
-`, Equals, "ip a | grep -v ether | sed 's/inet 10\\.0\\.2\\..*\\/24 brd/inet XX.XX.XX.XX\\/24 brd/' | sed 's/inet6 .*\\/64 scope/inet6 XX::XX:XX:XX:XX\\/64 scope/'")
+	s.CheckOutput(c,
+		"1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1\n"+
+			"    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00\n"+
+			"    inet 127.0.0.1/8 scope host lo\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 ::1/128 scope host \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth0\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3456/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet 10.1.0.41/24 scope global eth1\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3457/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet 10.31.168.85/24 scope global eth2\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3458/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			// TODO: I think it would be better if this was dhcp: false, but it could go either way
+			"5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth3\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3459/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"6: docker-sys: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000\n"+
+			"    inet 172.18.42.2/16 scope global docker-sys\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 XX::XX:XX:XX:XX/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"8: docker0: XXXXXXX......\n"+
+			"    inet 172.17.0.1/16 scope global docker0\n"+
+			"       valid_lft forever preferred_lft forever\n",
+		Equals,
+		"ip a | "+
+			"grep -v ether | "+
+			"sed 's/inet 10\\.0\\.2\\..*\\/24 brd/inet XX.XX.XX.XX\\/24 brd/' | "+
+			"sed 's/8: docker0: .*/8: docker0: XXXXXXX....../g' | "+
+			"sed '/inet6 fe80::5054:ff:fe12:.*\\/64/!s/inet6 .*\\/64 scope/inet6 XX::XX:XX:XX:XX\\/64 scope/'",
+		// fe80::18b6:9ff:fef5:be33
+	)
 
-	s.CheckOutput(c, `Kernel IP routing table
-Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
-0.0.0.0         10.31.168.1     0.0.0.0         UG    0      0        0 eth1
-0.0.0.0         10.0.2.2        0.0.0.0         UG    205    0        0 eth3
-10.0.2.0        0.0.0.0         255.255.255.0   U     205    0        0 eth3
-10.1.0.0        0.0.0.0         255.255.255.0   U     0      0        0 eth0
-10.31.168.0     0.0.0.0         255.255.255.0   U     0      0        0 eth1
-172.17.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker0
-172.18.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker-sys
-`, Equals, "route -n")
+	s.CheckOutput(c,
+		"Kernel IP routing table\n"+
+			"Destination     Gateway         Genmask         Flags Metric Ref    Use Iface\n"+
+			"0.0.0.0         10.1.0.1        0.0.0.0         UG    0      0        0 eth1\n"+
+			"0.0.0.0         10.0.2.2        0.0.0.0         UG    202    0        0 eth0\n"+
+			"0.0.0.0         10.0.2.2        0.0.0.0         UG    205    0        0 eth3\n"+
+			"10.0.2.0        0.0.0.0         255.255.255.0   U     202    0        0 eth0\n"+
+			"10.0.2.0        0.0.0.0         255.255.255.0   U     205    0        0 eth3\n"+
+			"10.1.0.0        0.0.0.0         255.255.255.0   U     0      0        0 eth1\n"+
+			"10.31.168.0     0.0.0.0         255.255.255.0   U     0      0        0 eth2\n"+
+			"172.17.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker0\n"+
+			"172.18.0.0      0.0.0.0         255.255.0.0     U     0      0        0 docker-sys\n",
+		Equals, "route -n")
+
+	s.CheckCall(c, "sudo ros config set rancher.network.interfaces.eth3.dhcp true")
+	//s.CheckCall(c, "sudo netconf")
+	s.Reboot(c)
+	s.CheckOutput(c,
+		"5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000\n"+
+			"    inet XX.XX.XX.XX/24 brd 10.0.2.255 scope global eth3\n"+
+			"       valid_lft forever preferred_lft forever\n"+
+			"    inet6 fe80::5054:ff:fe12:3459/64 scope link \n"+
+			"       valid_lft forever preferred_lft forever\n",
+		Equals,
+		"ip a show eth3 | "+
+			"grep -v ether | "+
+			"sed 's/inet 10\\.0\\.2\\..*\\/24 brd/inet XX.XX.XX.XX\\/24 brd/' | "+
+			"sed '/inet6 fe80::5054:ff:fe12:.*\\/64/!s/inet6 .*\\/64 scope/inet6 XX::XX:XX:XX:XX\\/64 scope/'",
+	)
 }


### PR DESCRIPTION
working towards fixing #1705

needs testing on:
- [x] Packet.net
- [ ] Packet.net iPXE
- [x] Digital Ocean - IPv4 looks good, IPv6 seems to have one right and one wrong - I presume its not removing (does the `dhcp --remove` only do the ipv4 stack?)
- [x] AWS
- [ ] GCE
- [x] bare metal PXE
- [x] bare metal installed
- [ ] bare metal ISO
- [x] vmware workstation
- [ ]  virtualbox

> Notes:
> I've just used `caddy` to serve the vmlinuz and initrd from my cloud-dev build box, and then used a modified version of https://github.com/rancher/os/blob/master/scripts/hosting/digitalocean/cloud-config.yml  - I'm thinking of making `make release` spit out a version of that file (and a pxeconf file) so its easy to test.

> Testing ~
> look into the `/var/lib/rancher/conf/metadata` file and make sure that only the listed ips and gateways are actually the ones on the interfaces
> if there are others, use `dmesg` (with `rancher.debug=true`) to work out what part of the ApplyNetwork code it comes from...