### PR TITLE
Don't need host dev mount for pre-created partition

### DIFF
--- a/scripts/run-install
+++ b/scripts/run-install
@@ -47,7 +47,6 @@ sudo kpartx -a ${DISK}
 
 docker run --privileged -it --rm \
     -v /dev/mapper:/dev/mapper \
-    -v /:/host \
     -v ${STATE}:/cluster \
     rancher/os:${VERSION} \
 	--isoinstallerloaded=1 \


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

add debug option passing, and fix pre-made partition suport (broke AMI building)
