### PR TITLE
fix downgrade from 0.8/0.9 to 0.7, and back again

### DIFF
--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -196,7 +196,7 @@ func osVersion(c *cli.Context) error {
 
 func startUpgradeContainer(image string, stage, force, reboot, kexec bool, upgradeConsole bool, kernelArgs string) error {
 	command := []string{
-		"-t", "upgrade",
+		"-t", "rancher-upgrade",
 		"-r", config.Version,
 	}
 

--- a/scripts/installer/BaseDockerfile.amd64
+++ b/scripts/installer/BaseDockerfile.amd64
@@ -8,7 +8,8 @@ ENV KERNEL_VERSION=${KERNEL_VERSION}
 
 # not installed atm udev, grub2, kexe-tools
 # parted: partprobe, e2fsprogs: mkfs.ext4, syslinux: extlinux&syslinux
-RUN apk --no-cache add syslinux parted e2fsprogs util-linux
+# e2fsprogs-extra: chattr
+RUN apk --no-cache add syslinux parted e2fsprogs e2fsprogs-extra util-linux
 
 COPY conf /scripts/
 COPY ./build/ros /bin/


### PR DESCRIPTION
needed 2 fixes, 
- need to use the old -t rancher-upgrade type so we can downgrade to older releases
- use `chattr` to remove the immutable bit from Syslinux ldlinux.sys so the installer can remove the syslinux backup dir.

goes further to fixing #1588