### PR TITLE
Create mount points for non-swap mounts; fixes #1506

### DIFF
--- a/tests/assets/test_23/cloud-config.yml
+++ b/tests/assets/test_23/cloud-config.yml
@@ -2,11 +2,11 @@
 write_files:
 - path: /test
   content: test
-- path: /home/rancher/test
 mounts:
 - ["/test", "/home/rancher/test", "", "bind"]
 - [/dev/vdb, /home/rancher/a, ext4, ""]
 - [/dev/vdb, /home/rancher/b, "", ""]
 - [/dev/vdb, /home/rancher/c, auto, defaults]
+- [/dev/vdb, /home/rancher/d, "auto", "defaults"]
 ssh_authorized_keys:
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC85w9stZyiLQp/DkVO6fqwiShYcj1ClKdtCqgHtf+PLpJkFReSFu8y21y+ev09gsSMRRrjF7yt0pUHV6zncQhVeqsZtgc5WbELY2DOYUGmRn/CCvPbXovoBrQjSorqlBmpuPwsStYLr92Xn+VVsMNSUIegHY22DphGbDKG85vrKB8HxUxGIDxFBds/uE8FhSy+xsoyT/jUZDK6pgq2HnGl6D81ViIlKecpOpWlW3B+fea99ADNyZNVvDzbHE5pcI3VRw8u59WmpWOUgT6qacNVACl8GqpBvQk8sw7O/X9DSZHCKafeD9G5k+GYbAUz92fKWrx/lOXfUXPS3+c8dRIF

--- a/tests/mounts_test.go
+++ b/tests/mounts_test.go
@@ -13,4 +13,5 @@ func (s *QemuSuite) TestMounts(c *C) {
 	s.CheckCall(c, "mount | grep /home/rancher/a")
 	s.CheckCall(c, "mount | grep /home/rancher/b")
 	s.CheckCall(c, "mount | grep /home/rancher/c")
+	s.CheckCall(c, "mount | grep /home/rancher/d")
 }


### PR DESCRIPTION
This change creates folders as necessary for filesystem mount points specified by the 'mounts' key in cloud-config.

Ref: #1506 #1792