### PR TITLE
add docker-init to console init for 17.03

### DIFF
--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -91,6 +91,7 @@ func consoleInitFunc() error {
 
 	for _, link := range []symlink{
 		{"/var/lib/rancher/engine/docker", "/usr/bin/docker"},
+		{"/var/lib/rancher/engine/docker-init", "/usr/bin/docker-init"},
 		{"/var/lib/rancher/engine/docker-containerd", "/usr/bin/docker-containerd"},
 		{"/var/lib/rancher/engine/docker-containerd-ctr", "/usr/bin/docker-containerd-ctr"},
 		{"/var/lib/rancher/engine/docker-containerd-shim", "/usr/bin/docker-containerd-shim"},


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

this change is bruteish - if you're using 1.12 or before, the softlink is made anyway, but points to nothing. (this was already the case when switching to 1.10.3)

`docker run --rm -it --init alpine sh`

this is not the proper fix - in 1.1.0, i'll need to re-do this to not have hard-coded paths in `ros`

