### PR TITLE
make qcow images customizable, and build one for Digital Ocean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ shell-bind: .dapper
 clean:
 	@./scripts/clean
 
-release: .dapper release-build openstack
+release: .dapper release-build qcows
 
 release-build:
 	mkdir -p dist
@@ -44,16 +44,13 @@ itest:
 	mkdir -p dist
 	./.dapper integration-test 2>&1 | tee dist/itest.log
 
-openstack:
+qcows:
 	cp dist/artifacts/rancheros.iso scripts/images/openstack/
-	cd scripts/images/openstack && ../../../.dapper
+	cd scripts/images/openstack && \
+		NAME=openstack ../../../.dapper
+	cd scripts/images/openstack && \
+		APPEND="console=tty1 rancher.debug=true printk.devkmsg=on notsc clocksource=kvm-clock rancher.network.interfaces.eth0.ipv4ll rancher.cloud_init.datasources=[digitalocean] rancher.autologin=tty1 rancher.autologin=ttyS0" NAME=digitalocean ../../../.dapper
 	cp ./scripts/images/openstack/dist/*.img dist/
-
-openstack-run:
-	qemu-system-x86_64 -curses \
-		-net nic -net user \
-		-m 2048M \
-		--hdc scripts/images/openstack/dist/rancheros-openstack.img
 
 rpi: release
 	# scripts/images/raspberry-pi-hypriot/dist/rancheros-raspberry-pi.zip

--- a/scripts/images/openstack/Dockerfile.dapper
+++ b/scripts/images/openstack/Dockerfile.dapper
@@ -12,3 +12,4 @@ CMD ["/source/scripts/build.sh"]
 
 ENV DAPPER_RUN_ARGS --device /dev/kvm
 ENV DAPPER_OUTPUT dist
+ENV DAPPER_ENV APPEND NAME

--- a/scripts/images/openstack/scripts/build.sh
+++ b/scripts/images/openstack/scripts/build.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-set -e
+set -ex
 
 cd $(dirname $0)/..
 
 mkdir -p {dist,build/openstack/latest}
+
+if [ "$APPEND" != "" ]; then
+    echo "--append ${APPEND}"
+    APPEND_PARAM="--append \"${APPEND}\""
+fi
 
 cat > build/openstack/latest/user_data << EOF
 #!/bin/bash
@@ -16,7 +21,11 @@ mount -t 9p -o trans=virtio,version=9p2000.L config-2 /mnt
 touch log
 sleep 5
 openvt -s -- tail -f log &
-ros install -d /dev/vda -f --no-reboot >log 2>&1
+ros install \
+    -d /dev/vda \
+    ${APPEND_PARAM} \
+    -f \
+    --no-reboot >log 2>&1
 
 touch /mnt/success
 EOF
@@ -32,5 +41,5 @@ kvm -curses \
 
 [ -f build/success ]
 
-echo Converting dist/rancheros-openstack.img
-qemu-img convert -c -O qcow2 build/hd.img dist/rancheros-openstack.img
+echo Converting dist/rancheros-${NAME}.img
+qemu-img convert -c -O qcow2 build/hd.img dist/rancheros-${NAME}.img

--- a/scripts/run
+++ b/scripts/run
@@ -25,8 +25,29 @@ while [ "$#" -gt 0 ]; do
         --pxe)
             BOOT_PXE=1
             ;;
+        --do)
+            BOOT_HD=1
+            QEMU=0
+            QIND=0
+            REBUILD=0
+            CONSOLEDISPLAY=1
+            USE_OPENSTACK_IMG="digitalocean"
+            ;;
+        --digitalocean)
+            BOOT_HD=1
+            QEMU=0
+            QIND=0
+            REBUILD=0
+            CONSOLEDISPLAY=1
+            USE_OPENSTACK_IMG="digitalocean"
+            ;;
         --openstack)
-            USE_OPENSTACK_IMG=1
+            BOOT_HD=1
+            QEMU=0
+            QIND=0
+            REBUILD=0
+            CONSOLEDISPLAY=1
+            USE_OPENSTACK_IMG="openstack"
             ;;
         --append)
             shift 1
@@ -155,12 +176,13 @@ if [ "$QEMU" == "1" ] || [ "$BOOT_ISO" == "1" ] || [ "$BOOT_HD" == "1" ]; then
 
     if [ ! -e ${HD} ]; then
         mkdir -p $(dirname ${HD})
-        if [ "$USE_OPENSTACK_IMG" == "1" ]; then
-           if [ ! -e "dist/rancheros-openstack.img" ]; then
+        if [ "$USE_OPENSTACK_IMG" != "" ]; then
+           if [ ! -e "dist/rancheros-${USE_OPENSTACK_IMG}.img" ]; then
                echo "please build the open stack image first (run make release)."
                exit 1
            fi
-           cp dist/rancheros-openstack.img $HD
+           cp dist/rancheros-${USE_OPENSTACK_IMG}.img $HD
+           qemu-img resize ${HD} +10GB
         else
             if [ ¨$INSTALLED¨ == ¨1¨ ]; then
                 ./scripts/create-installed


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

- idk how we add `rancher.resize_device` - as that'll depend on what the state device is?
- it'd be nice to remove the syslinux `boot:` prompt timeout for hosting systems that don't give access to it.
