### PR TITLE
give init stages a label so the log tells us what is starting, not what number it is.

### DIFF
--- a/config/data_funcs.go
+++ b/config/data_funcs.go
@@ -10,16 +10,29 @@ import (
 )
 
 type CfgFunc func(*CloudConfig) (*CloudConfig, error)
+type CfgFuncData struct {
+	Name string
+	Func CfgFunc
+}
+type CfgFuncs []CfgFuncData
 
-func ChainCfgFuncs(cfg *CloudConfig, cfgFuncs ...CfgFunc) (*CloudConfig, error) {
-	for i, cfgFunc := range cfgFuncs {
-		log.Debugf("[%d/%d] Starting", i+1, len(cfgFuncs))
+func ChainCfgFuncs(cfg *CloudConfig, cfgFuncs CfgFuncs) (*CloudConfig, error) {
+	len := len(cfgFuncs)
+	for c, d := range cfgFuncs {
+		i := c + 1
+		name := d.Name
+		cfgFunc := d.Func
+		if cfg == nil {
+			log.Infof("[%d/%d] Starting %s WITH NIL cfg", i, len, name)
+		} else {
+			log.Infof("[%d/%d] Starting %s", i, len, name)
+		}
 		var err error
 		if cfg, err = cfgFunc(cfg); err != nil {
-			log.Errorf("Failed [%d/%d] %s", i+1, len(cfgFuncs), err)
+			log.Errorf("Failed [%d/%d] %s: %s", i, len, name, err)
 			return cfg, err
 		}
-		log.Debugf("[%d/%d] Done %d%%", i+1, len(cfgFuncs), ((i + 1) * 100 / len(cfgFuncs)))
+		log.Debugf("[%d/%d] Done %s", i, len, name)
 	}
 	return cfg, nil
 }

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -68,8 +68,10 @@ func bootstrap(cfg *config.CloudConfig) error {
 	defer stopDocker(c)
 
 	_, err = config.ChainCfgFuncs(cfg,
-		loadImages,
-		bootstrapServices)
+		[]config.CfgFuncData{
+			config.CfgFuncData{"bootstrap loadImages", loadImages},
+			config.CfgFuncData{"bootstrap Services", bootstrapServices},
+		})
 	return err
 }
 
@@ -82,7 +84,9 @@ func runCloudInitServices(cfg *config.CloudConfig) error {
 	defer stopDocker(c)
 
 	_, err = config.ChainCfgFuncs(cfg,
-		loadImages,
-		runCloudInitServiceSet)
+		[]config.CfgFuncData{
+			config.CfgFuncData{"cloudinit loadImages", loadImages},
+			config.CfgFuncData{"cloudinit Services", runCloudInitServiceSet},
+		})
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/containernetworking/cni/plugins/ipam/host-local"
 	"github.com/containernetworking/cni/plugins/main/bridge"
 	"github.com/docker/docker/docker"
@@ -42,6 +45,18 @@ var entrypoints = map[string]func(){
 }
 
 func main() {
+	if 0 == 1 {
+		// TODO: move this into a "dev/debug +build"
+		fmt.Fprintf(os.Stderr, "ros main(%s) ppid:%d - print to stdio\n", os.Args[0], os.Getppid())
+
+		filename := "/dev/kmsg"
+		f, err := os.OpenFile(filename, os.O_WRONLY, 0644)
+		if err == nil {
+			fmt.Fprintf(f, "ros main(%s) ppid:%d - print to %s\n", os.Args[0], os.Getppid(), filename)
+		}
+		f.Close()
+	}
+
 	for name, f := range entrypoints {
 		reexec.Register(name, f)
 	}


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

This would add the following info to the non-debug boot output:

```
[   41.137976] sr 1:0:0:0: Attached scsi generic sg0 type 5
[   41.202457] Freeing unused kernel memory: 1456K (ffffffffacd6d000 - ffffffffaced9000)
[   41.202727] Write protecting the kernel read-only data: 12288k
[   41.207942] Freeing unused kernel memory: 1108K (ffff926c666eb000 - ffff926c66800000)
[   41.218331] Freeing unused kernel memory: 384K (ffff926c66ba0000 - ffff926c66c00000)
MainInit() - print to stdio
INFO[0000] MainInit() start
INFO[0000] [1/19] Starting preparefs WITH NIL cfg
INFO[0000] [2/19] Starting save init cmdline WITH NIL cfg
INFO[0000] [3/19] Starting mount OEM WITH NIL cfg
[   41.832428] clocksource: Switched to clocksource tsc
INFO[0001] [4/19] Starting debug save cfg
[   42.298449] random: fast init done
INFO[0001] [5/19] Starting load modules
INFO[0001] [6/19] Starting b2d env
INFO[0001] [7/19] Starting mount and bootstrap
INFO[0001] [8/19] Starting cloud-init
INFO[0002] [1/2] Starting cloudinit loadImages
INFO[0002] Waiting for Docker at unix:///var/run/system-docker.sock
INFO[0002] Waiting for Docker at unix:///var/run/system-docker.sock
[   43.701671] time="2017-05-03T02:56:51Z" level=debug msg="START: [/usr/bin/system-docker daemon --host unix:///var/run/system-docker.sock --graph /var/lib/system-docker --storage-driver overlay --bridge none --group root --restart=false --userland-proxy=false] in /"
INFO[0002] Connected to Docker at unix:///var/run/system-docker.sock
INFO[0002] Loading images from /usr/share/ros/images.tar
INFO[0018] Done loading images from /usr/share/ros/images.tar
INFO[0018] [2/2] Starting cloudinit Services
INFO[0018] Running cloud-init services
INFO[0018] Project [cloudinit]: Starting project
INFO[0019] [0/1] [cloud-init]: Starting
[   61.299947] cgroup: docker-runc (193) created nested cgroup for controller "memory" which has incomplete hierarchy support. Nested cgroups may change behavior in the future.
[   61.300711] cgroup: "memory" requires setting use_hierarchy to 1 on the root
[   62.107789] time="2017-05-03T02:57:09Z" level=debug msg="START: [/usr/bin/ros entrypoint cloud-init-save] in /"
[   62.411508] time="2017-05-03T02:57:09Z" level=error msg="symlink /usr/bin/ros /usr/bin/cloud-init-save: file exists"
[   62.570427] time="2017-05-03T02:57:10Z" level=debug msg="START: [cloud-init-save] in /"
[   62.571723] time="2017-05-03T02:57:10Z" level=info msg="Running cloud-init-save"
[   62.596190] udevd[221]: starting version 3.2
[   62.631112] udevd[222]: starting eudev-3.2
[   62.922870] piix4_smbus 0000:00:01.3: SMBus Host Controller at 0x700, revision 0
[   63.528808] kvm: Nested Virtualization enabled
[   63.637294] time="2017-05-03T02:57:11Z" level=debug msg=SaveCloudConfig
[   63.906470] time="2017-05-03T02:57:11Z" level=debug msg="init: SaveCloudConfig(pre ApplyNetworkConfig): netconf.NetworkConfig{PreCmds:[]string(nil), DNS:netconf.DNSConfig{Nameservers:[]string(nil), Search:[]string(nil)}, Interfaces:map[string]netconf.InterfaceConfig(nil), PostCmds:[]string(nil), HTTPProxy:\"\", HTTPSProxy:\"\", NoProxy:\"\"}"
[   63.908261] time="2017-05-03T02:57:11Z" level=info msg="Apply Network Config"
[   63.910347] time="2017-05-03T02:57:11Z" level=debug msg="Config: &netconf.NetworkConfig{PreCmds:[]string(nil), DNS:netconf.DNSConfig{Nameservers:[]string(nil), Search:[]string(nil)}, Interfaces:map[string]netconf.InterfaceConfig{\"eth*\":netconf.InterfaceConfig{Match:\"\", DHCP:true, DHCPArgs:\"\", Address:\"\", Addresses:[]string(nil), IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}, \"lo\":netconf.InterfaceConfig{Match:\"\", DHCP:false, DHCPArgs:\"\", Address:\"\", Addresses:[]string{\"127.0.0.1/8\", \"::1/128\"}, IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}}, PostCmds:[]string(nil), HTTPProxy:\"\", HTTPSProxy:\"\", NoProxy:\"\"}"
[   63.917299] time="2017-05-03T02:57:11Z" level=info msg="Applying 127.0.0.1/8 to lo"
[   63.919288] time="2017-05-03T02:57:11Z" level=info msg="Applying ::1/128 to lo"
[   63.921447] time="2017-05-03T02:57:11Z" level=info msg="Apply Network Config RunDhcp"
[   63.921879] time="2017-05-03T02:57:11Z" level=debug msg=RunDhcp
[   63.924527] time="2017-05-03T02:57:11Z" level=info msg="Running DHCP on eth0: dhcpcd -MA4 -e force_hostname=true eth0"
[   64.129430] input: ImExPS/2 Generic Explorer Mouse as /devices/platform/i8042/serio1/input/input3
[   64.693968] time="2017-05-03T02:57:12Z" level=info msg="Apply Network Config SyncHostname"
[   64.695756] time="2017-05-03T02:57:12Z" level=debug msg="datasources that will be consided: []string{\"configdrive:/media/config-2\"}"
[   64.704670] time="2017-05-03T02:57:12Z" level=info msg="cloud-init: Checking availability of \"cloud-drive\"\n"
[   65.120652] FS-Cache: Loaded
[   65.130294] 9p: Installing v9fs 9p2000 file system support
[   65.132515] FS-Cache: Netfs '9p' registered for caching
[   65.150919] time="2017-05-03T02:57:12Z" level=info msg="cloud-init: Datasource available: cloud-drive: /media/config-2"
[   65.153079] time="2017-05-03T02:57:12Z" level=info msg="Fetching user-data from datasource cloud-drive: /media/config-2"
[   65.565887] time="2017-05-03T02:57:13Z" level=debug msg="Attempting to read from \"/media/config-2/openstack/latest/user_data\"\n"
[   65.572865] time="2017-05-03T02:57:13Z" level=info msg="Fetching meta-data from datasource of type cloud-drive"
[   65.980326] time="2017-05-03T02:57:13Z" level=debug msg="Attempting to read from \"/media/config-2/openstack/latest/meta_data.json\"\n"
[   65.998541] time="2017-05-03T02:57:13Z" level=info msg="Wrote to /var/lib/rancher/conf/cloud-config.d/boot.yml"
[   66.001463] time="2017-05-03T02:57:13Z" level=info msg="Wrote to /var/lib/rancher/conf/metadata"
[   66.003448] time="2017-05-03T02:57:13Z" level=info msg="not writing /var/lib/rancher/conf/cloud-config.d/network.yml: its all defaults."
[   66.266967] time="2017-05-03T02:57:13Z" level=debug msg="init: SaveCloudConfig(post ApplyNetworkConfig): netconf.NetworkConfig{PreCmds:[]string(nil), DNS:netconf.DNSConfig{Nameservers:[]string(nil), Search:[]string(nil)}, Interfaces:map[string]netconf.InterfaceConfig(nil), PostCmds:[]string(nil), HTTPProxy:\"\", HTTPSProxy:\"\", NoProxy:\"\"}"
[   66.268933] time="2017-05-03T02:57:13Z" level=info msg="Apply Network Config"
[   66.270459] time="2017-05-03T02:57:13Z" level=debug msg="Config: &netconf.NetworkConfig{PreCmds:[]string(nil), DNS:netconf.DNSConfig{Nameservers:[]string(nil), Search:[]string(nil)}, Interfaces:map[string]netconf.InterfaceConfig{\"lo\":netconf.InterfaceConfig{Match:\"\", DHCP:false, DHCPArgs:\"\", Address:\"\", Addresses:[]string{\"127.0.0.1/8\", \"::1/128\"}, IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}, \"eth*\":netconf.InterfaceConfig{Match:\"\", DHCP:true, DHCPArgs:\"\", Address:\"\", Addresses:[]string(nil), IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}}, PostCmds:[]string(nil), HTTPProxy:\"\", HTTPSProxy:\"\", NoProxy:\"\"}"
[   66.274979] time="2017-05-03T02:57:13Z" level=info msg="Applying 127.0.0.1/8 to lo"
[   66.276439] time="2017-05-03T02:57:13Z" level=info msg="Applying ::1/128 to lo"
[   66.278201] time="2017-05-03T02:57:13Z" level=info msg="Apply Network Config RunDhcp"
[   66.278596] time="2017-05-03T02:57:13Z" level=debug msg=RunDhcp
[   66.280484] time="2017-05-03T02:57:13Z" level=info msg="Running DHCP on eth0: dhcpcd -MA4 -e force_hostname=true eth0"
[   66.314449] time="2017-05-03T02:57:13Z" level=info msg="Apply Network Config SyncHostname"
INFO[0026] [1/1] [cloud-init]: Started
INFO[0026] Project [cloudinit]: Project started
INFO[0026] [9/19] Starting read cfg files
ERRO[0026] open /var/lib/rancher/conf/cloud-config.d/network.yml: no such file or directory
INFO[0026] [10/19] Starting switchroot
INFO[0026] [11/19] Starting mount OEM2
INFO[0026] [12/19] Starting write cfg files
INFO[0026] [13/19] Starting b2d Env
INFO[0027] [14/19] Starting preparefs2
INFO[0027] [15/19] Starting load modules2
INFO[0027] [16/19] Starting set proxy env
INFO[0027] [17/19] Starting init SELinux
SELinux:  Could not load policy file /etc/selinux/ros/policy/policy.29:  Read-only file system
INFO[0027] [18/19] Starting setupSharedRoot
INFO[0027] [19/19] Starting sysinit
INFO[0027] Launching System Docker
[   68.738498] DEBU[0000] START: [/usr/bin/ros-sysinit] in /
[   68.877624] time="2017-05-03T02:57:16Z" level=debug msg="START: [system-docker daemon --log-opt max-file=2 --log-opt max-size=25m --userland-proxy=false --group root --storage-driver overlay --exec-root /var/run/system-docker --restart=false --pidfile /var/run/system-docker.pid --config-file /etc/docker/system-docker.json --graph /var/lib/system-docker --host unix:///var/run/system-docker.sock] in /"
> INFO[0000] [1/4] Starting loadImages
[   69.239323] INFO[0000] [1/4] Starting loadImages
[   69.239728] DEBU[0000] Looking for images at /usr/share/ros
[   69.240314] DEBU[0000] Found images.tar
> INFO[0000] Loading images from /usr/share/ros/images.tar
[   69.345768] INFO[0000] Loading images from /usr/share/ros/images.tar
> INFO[0016] Done loading images from /usr/share/ros/images.tar
[   85.297297] INFO[0016] Done loading images from /usr/share/ros/images.tar
[   85.297729] DEBU[0016] [1/4] Done loadImages
> INFO[0016] [2/4] Starting start project
[   85.298296] INFO[0016] [2/4] Starting start project
> INFO[0017] Project [os]: Starting project
[   85.627828] INFO[0017] Project [os]: Starting project
[   85.629434] DEBU[0017] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
[   85.630166] DEBU[0017] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
[   85.630759] DEBU[0017] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
> INFO[0017] [0/16] [system-volumes]: Starting
[   85.867270] INFO[0017] [0/16] [system-volumes]: Starting
> INFO[0017] [0/16] [command-volumes]: Starting
[   85.888677] INFO[0017] [0/16] [command-volumes]: Starting
> INFO[0017] [0/16] [media-volumes]: Starting
[   86.154589] INFO[0017] [0/16] [media-volumes]: Starting
> INFO[0017] [0/16] [container-data-volumes]: Starting
[   86.155187] INFO[0017] [0/16] [container-data-volumes]: Starting
> INFO[0017] [0/16] [user-volumes]: Starting
[   86.196943] INFO[0017] [0/16] [user-volumes]: Starting
[   87.680713] DEBU[0019] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0019] [1/16] [system-volumes]: Started
[   87.697406] INFO[0019] [1/16] [system-volumes]: Started
[   87.773802] DEBU[0019] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0019] [2/16] [command-volumes]: Started
[   87.814207] INFO[0019] [2/16] [command-volumes]: Started
> INFO[0019] [2/16] [udev-cold]: Starting
[   87.839287] INFO[0019] [2/16] [udev-cold]: Starting
> INFO[0019] [2/16] [acpid]: Starting
[   87.839849] INFO[0019] [2/16] [acpid]: Starting
> INFO[0019] [2/16] [syslog]: Starting
[   87.840568] INFO[0019] [2/16] [syslog]: Starting
[   87.863889] DEBU[0019] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0019] [3/16] [user-volumes]: Started
[   87.879912] INFO[0019] [3/16] [user-volumes]: Started
[   88.179759] DEBU[0019] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0019] [4/16] [media-volumes]: Started
[   88.185874] INFO[0019] [4/16] [media-volumes]: Started
[   88.275845] DEBU[0019] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0019] [5/16] [container-data-volumes]: Started
[   88.289976] INFO[0019] [5/16] [container-data-volumes]: Started
> INFO[0019] [5/16] [all-volumes]: Starting
[   88.290638] INFO[0019] [5/16] [all-volumes]: Starting
[   89.382076] DEBU[0020] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
[   89.414525] DEBU[0020] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0023] [6/16] [acpid]: Started
[   92.145651] INFO[0023] [6/16] [acpid]: Started
[   92.265773] DEBU[0023] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0023] [7/16] [all-volumes]: Started
[   92.292985] INFO[0023] [7/16] [all-volumes]: Started
[   92.314875] DEBU[0023] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
[   92.887192] time="2017-05-03T02:57:40Z" level=debug msg="START: [/usr/bin/ros entrypoint ros udev-settle] in /"
[   93.250494] time="2017-05-03T02:57:40Z" level=debug msg="START: [/usr/bin/ros entrypoint /usr/sbin/acpid -f] in /"
> INFO[0026] [8/16] [syslog]: Started
[   94.511643] INFO[0026] [8/16] [syslog]: Started
May  3 02:57:42 acpid: starting up with netlink and the input layer
May  3 02:57:42 acpid: 2 rules loaded
May  3 02:57:42 acpid: waiting for events: event logging is off
[   94.846772] time="2017-05-03T02:57:42Z" level=debug msg="START: [/usr/bin/ros entrypoint rsyslogd -n] in /"
[   94.918557] time="2017-05-03T02:57:42Z" level=debug msg="START: [ros udev-settle] in /"
[   94.977324] udevd[16]: starting version 3.2
[   95.042721] udevd[17]: starting eudev-3.2
> INFO[0028] [9/16] [udev-cold]: Started
[   97.229228] INFO[0028] [9/16] [udev-cold]: Started
> INFO[0028] [9/16] [udev]: Starting
[   97.229904] INFO[0028] [9/16] [udev]: Starting
[   98.074320] DEBU[0029] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0030] [10/16] [udev]: Started
[   99.077041] INFO[0030] [10/16] [udev]: Started
> INFO[0030] [10/16] [network]: Starting
[   99.078921] INFO[0030] [10/16] [network]: Starting
[   99.383497] time="2017-05-03T02:57:46Z" level=debug msg="START: [/usr/bin/ros entrypoint udevd] in /"
[  100.158597] udevd[1]: starting version 3.2
[  100.191937] udevd[1]: starting eudev-3.2
[  100.481318] DEBU[0031] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0033] [11/16] [network]: Started
[  101.536955] INFO[0033] [11/16] [network]: Started
[  101.751166] time="2017-05-03T02:57:49Z" level=debug msg="START: [/usr/bin/ros entrypoint netconf] in /"
[  102.330011] DEBU[0033] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
[  102.330768] DEBU[0033] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
[  102.331384] DEBU[0033] Using /proc/version to set rancher.environment.KERNEL_VERSION = 4.9.25-rancher
> INFO[0034] [11/16] [ntp]: Starting
[  102.573057] INFO[0034] [11/16] [ntp]: Starting
[  102.973700] time="2017-05-03T02:57:50Z" level=debug msg="START: [netconf] in /"
[  103.551659] time="2017-05-03T02:57:51Z" level=info msg="Apply Network Config"
[  103.563867] time="2017-05-03T02:57:51Z" level=debug msg="Config: &netconf.NetworkConfig{PreCmds:[]string(nil), DNS:netconf.DNSConfig{Nameservers:[]string(nil), Search:[]string(nil)}, Interfaces:map[string]netconf.InterfaceConfig{\"eth*\":netconf.InterfaceConfig{Match:\"\", DHCP:true, DHCPArgs:\"\", Address:\"\", Addresses:[]string(nil), IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}, \"lo\":netconf.InterfaceConfig{Match:\"\", DHCP:false, DHCPArgs:\"\", Address:\"\", Addresses:[]string{\"127.0.0.1/8\", \"::1/128\"}, IPV4LL:false, Gateway:\"\", GatewayIpv6:\"\", MTU:0, Bridge:\"\", Bond:\"\", BondOpts:map[string]string(nil), PostUp:[]string(nil), PreUp:[]string(nil), Vlans:\"\"}}, PostCmds:[]string(nil), HTTPProxy:\"\", HTTPSProxy:\"\", NoProxy:\"\"}"
[  103.581300] time="2017-05-03T02:57:51Z" level=info msg="Applying 127.0.0.1/8 to lo"
[  103.582087] time="2017-05-03T02:57:51Z" level=info msg="Applying ::1/128 to lo"
[  103.590938] time="2017-05-03T02:57:51Z" level=info msg="Apply Network Config RunDhcp"
[  103.591768] time="2017-05-03T02:57:51Z" level=debug msg=RunDhcp
[  103.593802] time="2017-05-03T02:57:51Z" level=info msg="Running DHCP on eth0: dhcpcd -MA4 -e force_hostname=true eth0"
[  103.650251] DEBU[0035] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0036] [12/16] [ntp]: Started
[  105.066591] INFO[0036] [12/16] [ntp]: Started
> INFO[0036] [12/16] [cloud-init-execute]: Starting
[  105.070974] INFO[0036] [12/16] [cloud-init-execute]: Starting
[  105.747322] time="2017-05-03T02:57:53Z" level=debug msg="START: [/usr/bin/ros entrypoint ntpd --nofork -g] in /"
[  106.016145] DEBU[0037] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
[  106.031877] time="2017-05-03T02:57:53Z" level=info msg="Apply Network Config SyncHostname"
[  107.729686] time="2017-05-03T02:57:55Z" level=debug msg="START: [/usr/bin/ros entrypoint cloud-init-execute -pre-console] in /"
[  108.221613] time="2017-05-03T02:57:56Z" level=debug msg="START: [cloud-init-execute -pre-console] in /"
[  108.223309] time="2017-05-03T02:57:56Z" level=info msg="Running cloud-init-execute: pre-console=true, console=false"
> INFO[0041] [13/16] [cloud-init-execute]: Started
[  109.328798] INFO[0041] [13/16] [cloud-init-execute]: Started
> INFO[0041] [13/16] [console]: Starting
[  109.329390] INFO[0041] [13/16] [console]: Starting
[  110.010987] DEBU[0042] Rebuild values                                newRebuildLabel=always origRebuildLabel=always outOfSync=false rebuildLabelChanged=false
> INFO[0042] Rebuilding console
[  110.012413] INFO[0042] Rebuilding console
> INFO[0043] [14/16] [console]: Started
[  111.299037] INFO[0043] [14/16] [console]: Started
> INFO[0043] [14/16] [preload-user-images]: Starting
[  111.301142] INFO[0043] [14/16] [preload-user-images]: Starting
> INFO[0043] [14/16] [docker]: Starting
[  111.301674] INFO[0043] [14/16] [docker]: Starting
[  111.763939] time="2017-05-03T02:57:59Z" level=debug msg="START: [/usr/bin/ros entrypoint ros console-init] in /"
[  112.736780] time="2017-05-03T02:58:00Z" level=debug msg="START: [ros console-init] in /"
[  113.036884] DEBU[0045] Rebuild values                                newRebuildLabel= origRebuildLabel= outOfSync=false rebuildLabelChanged=false
> INFO[0047] [15/16] [docker]: Started
> INFO[0055] [16/16] [preload-user-images]: Started
> INFO[0055] Project [os]: Project started
> INFO[0055] [3/4] Starting sync
> INFO[0055] [4/4] Starting banner
> INFO[0055] RancherOS 1eebab5-dirty started


               ,        , ______                 _                 _____ _____TM
  ,------------|'------'| | ___ \               | |               /  _  /  ___|
 / .           '-'    |-  | |_/ /__ _ _ __   ___| |__   ___ _ __  | | | \ '--.
 \/|             |    |   |    // _' | '_ \ / __| '_ \ / _ \ '__' | | | |'--. \
   |   .________.'----'   | |\ \ (_| | | | | (__| | | |  __/ |    | \_/ /\__/ /
   |   |        |   |     \_| \_\__,_|_| |_|\___|_| |_|\___|_|     \___/\____/
   \___/        \___/     Linux 4.9.25-rancher

         RancherOS 1eebab5-dirty rancher-dev ttyS0
         docker-sys: 172.18.42.2 eth0: 10.0.2.15 lo: 127.0.0.1
rancher-dev login: rancher (automatic login)

[rancher@rancher-dev ~]$
```