### PR TITLE
only 10 respawns ever, even if not respawnning too fast

### DIFF
--- a/cmd/respawn/respawn.go
+++ b/cmd/respawn/respawn.go
@@ -144,7 +144,7 @@ func execute(line string, wg *sync.WaitGroup) {
 		count++
 
 		if count > 10 {
-			if start.Sub(time.Now()) <= (1 * time.Second) {
+			if time.Now().Sub(start) <= (1 * time.Second) {
 				log.Errorf("%s : restarted too fast, not executing", line)
 				break
 			}


### PR DESCRIPTION
changing start-now() to now()-start
start - now() is always negative, so only 10 respawns were ever made, regardless of how much time have passed.