### PR TITLE
Remove the user-docker link, its redundant

### DIFF
--- a/cmd/control/selinux.go
+++ b/cmd/control/selinux.go
@@ -17,7 +17,6 @@ func selinuxCommand() cli.Command {
 			"--net", "host", "--pid", "host", "--ipc", "host",
 			"-v", "/usr/bin/docker:/usr/bin/docker.dist:ro",
 			"-v", "/usr/bin/ros:/usr/bin/dockerlaunch:ro",
-			"-v", "/usr/bin/ros:/usr/bin/user-docker:ro",
 			"-v", "/usr/bin/ros:/usr/bin/system-docker:ro",
 			"-v", "/usr/bin/ros:/sbin/poweroff:ro",
 			"-v", "/usr/bin/ros:/sbin/reboot:ro",

--- a/cmd/control/user_docker.go
+++ b/cmd/control/user_docker.go
@@ -25,7 +25,6 @@ import (
 const (
 	defaultStorageContext = "console"
 	dockerPidFile         = "/var/run/docker.pid"
-	userDocker            = "user-docker"
 	sourceDirectory       = "/engine"
 	destDirectory         = "/var/lib/rancher/engine"
 )

--- a/docs/os/system-services/system-docker-volumes/index.md
+++ b/docs/os/system-services/system-docker-volumes/index.md
@@ -36,7 +36,6 @@ Provides necessary command binaries (read-only), used by system services:
 /usr/bin/docker-runc.dist
 /usr/bin/docker.dist
 /usr/bin/dockerlaunch
-/usr/bin/user-docker
 /usr/bin/system-docker
 /sbin/poweroff
 /sbin/reboot


### PR DESCRIPTION
it was replaced a while back by a hidden `ros user-docker` command