### PR TITLE
Prevent ctrl-c in qemu from exiting vm - use ctrl-] instead

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -264,6 +264,11 @@ if [ "$QEMU" == "1" ]; then
     else
         INSTALLED_ARGS="-kernel ${KERNEL} -initrd ${INITRD}"
     fi
+
+    # don't quit qemu using ctrl-c
+    stty intr ^]
+    stty susp ^]
+    stty quit ^]
     set -x
     exec qemu-system-${QEMUARCH} \
             ${DISPLAY_OPTS} \
@@ -293,6 +298,10 @@ elif [ "$BOOT_ISO" == "1" ] ||
             echo "----- $ISO_OPTS"
     fi
     set -x
+    # don't quit qemu using ctrl-c
+    stty intr ^]
+    stty susp ^]
+    stty quit ^]
     exec qemu-system-${QEMUARCH} \
             ${DISPLAY_OPTS} \
             ${CLOUD_CONFIG_DISK} \


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>