### PR TITLE
Bounce the syslog service so it notices the hostname change

### DIFF
--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -1,6 +1,9 @@
 package network
 
 import (
+	"golang.org/x/net/context"
+
+	"github.com/rancher/os/docker"
 	"github.com/rancher/os/log"
 
 	"github.com/docker/libnetwork/resolvconf"
@@ -14,6 +17,16 @@ func Main() {
 
 	cfg := config.LoadConfig()
 	ApplyNetworkConfig(cfg)
+
+	log.Infof("Restart syslog")
+	client, err := docker.NewSystemClient()
+	if err != nil {
+		log.Error(err)
+	}
+
+	if err := client.ContainerRestart(context.Background(), "syslog", 10); err != nil {
+		log.Error(err)
+	}
 
 	select {}
 }


### PR DESCRIPTION
for #1804

The hostname is changed to the cloud-init user-data one pretty late in the boot process - at the `cloud-init-execute` - so you actually see the original meta-data based one until then.