### PR TITLE
Use engine registry mirror

### DIFF
--- a/scripts/run-common
+++ b/scripts/run-common
@@ -48,4 +48,8 @@ REBUILD=1
 QEMUARCH=${qemuarch["${ARCH}"]}
 TTYCONS=${ttycons["${ARCH}"]}
 
-DEFAULT_KERNEL_ARGS="printk.devkmsg=on rancher.debug=true rancher.password=rancher console=${TTYCONS} rancher.autologin=${TTYCONS}"
+if [ "$ENGINE_REGISTRY_MIRROR" != "" ]; then
+	REGISTRY_MIRROR="rancher.bootstrap_docker.registry_mirror=${ENGINE_REGISTRY_MIRROR} rancher.system_docker.registry_mirror=${ENGINE_REGISTRY_MIRROR} rancher.docker.registry_mirror=${ENGINE_REGISTRY_MIRROR}"
+fi
+
+DEFAULT_KERNEL_ARGS="printk.devkmsg=on rancher.debug=true rancher.password=rancher console=${TTYCONS} rancher.autologin=${TTYCONS} ${REGISTRY_MIRROR} "


### PR DESCRIPTION
if you've set `ENGINE_REGISTRY_MIRROR=http://10.10.10.23:5555` (which works on docker-machine too), then `./scripts/run` will use it to speed for your qemu vm's docker pulls too.