### PR TITLE
working towards v1.0.3 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -80,9 +80,9 @@ ARG OS_SERVICES_REPO=https://raw.githubusercontent.com/${OS_REPO}/os-services
 ARG IMAGE_NAME=${OS_REPO}/os
 ARG DFS_IMAGE=${OS_REPO}/docker:v${DOCKER_VERSION}-2
 
-ARG OS_BASE_URL_amd64=https://github.com/rancher/os-base/releases/download/v2017.02.3-1/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2017.02.3-1/os-base_arm64.tar.xz
-ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2017.02.3-1/os-base_arm.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp-all/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp.all/os-base_arm64.tar.xz
+ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp.all/os-base_arm.tar.xz
 ######################################################
 
 # Set up environment and export all ARGS as ENV

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -62,7 +62,7 @@ ARG DOCKER_BUILD_VERSION=1.10.3
 ARG DOCKER_BUILD_PATCH_VERSION=v${DOCKER_BUILD_VERSION}-ros1
 ARG SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION_amd64=4.9.30-rancher
+ARG KERNEL_VERSION_amd64=4.9.33-rancher
 ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION_amd64}/linux-${KERNEL_VERSION_amd64}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/imikushin/os-kernel/releases/download/Estuary-4.4.0-arm64.8/linux-4.4.0-rancher-arm64.tar.gz
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -62,7 +62,7 @@ ARG DOCKER_BUILD_VERSION=1.10.3
 ARG DOCKER_BUILD_PATCH_VERSION=v${DOCKER_BUILD_VERSION}-ros1
 ARG SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION_amd64=4.9.33-rancher-4.9.34rc
+ARG KERNEL_VERSION_amd64=4.9.33-rancher-ssp1
 ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION_amd64}/linux-${KERNEL_VERSION_amd64}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/imikushin/os-kernel/releases/download/Estuary-4.4.0-arm64.8/linux-4.4.0-rancher-arm64.tar.gz
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -62,7 +62,7 @@ ARG DOCKER_BUILD_VERSION=1.10.3
 ARG DOCKER_BUILD_PATCH_VERSION=v${DOCKER_BUILD_VERSION}-ros1
 ARG SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION_amd64=4.9.33-rancher
+ARG KERNEL_VERSION_amd64=4.9.33-rancher-4.9.34rc
 ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION_amd64}/linux-${KERNEL_VERSION_amd64}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/imikushin/os-kernel/releases/download/Estuary-4.4.0-arm64.8/linux-4.4.0-rancher-arm64.tar.gz
 
@@ -81,8 +81,8 @@ ARG IMAGE_NAME=${OS_REPO}/os
 ARG DFS_IMAGE=${OS_REPO}/docker:v${DOCKER_VERSION}-2
 
 ARG OS_BASE_URL_amd64=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp-all/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp.all/os-base_arm64.tar.xz
-ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp.all/os-base_arm.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp-all/os-base_arm64.tar.xz
+ARG OS_BASE_URL_arm=https://github.com/rancher/os-base/releases/download/v2017.02.3-glibc-ssp-all/os-base_arm.tar.xz
 ######################################################
 
 # Set up environment and export all ARGS as ENV


### PR DESCRIPTION
mostly because of https://github.com/rancher/os/issues/1932

along the way, rpi32 is at 4.4.50, rpi64 is at 4.9.33, and amd64 is 4.9.34+some stack patches

all 3 platforms have been moved to glibc and updated to use buildroot 2017.02.3 rebuilt with the existing 6.x gcc stack guard option.

the kernel changes are intended to prevent container workloads from exploiting the issue, as they may not be rebuilt with stack-clash prevention options.