### PR TITLE
Log rotation system service

### DIFF
--- a/images/02-logrotate/Dockerfile
+++ b/images/02-logrotate/Dockerfile
@@ -1,0 +1,5 @@
+FROM rancher/os-base
+COPY logrotate.d/ /usr/share/logrotate/logrotate.d/
+COPY logrotate.conf /etc/logrotate.conf
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/images/02-logrotate/entrypoint.sh
+++ b/images/02-logrotate/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp /usr/share/logrotate/logrotate.d/* /etc/logrotate.d
+
+exec /usr/bin/ros entrypoint "$@"

--- a/images/02-logrotate/logrotate.conf
+++ b/images/02-logrotate/logrotate.conf
@@ -1,0 +1,3 @@
+compress
+
+include /etc/logrotate.d

--- a/images/02-logrotate/logrotate.d/docker
+++ b/images/02-logrotate/logrotate.d/docker
@@ -1,0 +1,8 @@
+/var/log/docker.log
+/var/log/system-docker.log
+{
+	rotate 7
+	daily
+	missingok
+	copytruncate
+}

--- a/images/02-syslog/Dockerfile
+++ b/images/02-syslog/Dockerfile
@@ -1,0 +1,4 @@
+FROM rancher/os-base
+COPY logrotate.d/ /usr/share/logrotate/logrotate.d/
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/images/02-syslog/entrypoint.sh
+++ b/images/02-syslog/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp /usr/share/logrotate/logrotate.d/* /etc/logrotate.d
+
+exec /usr/bin/ros entrypoint "$@"

--- a/images/02-syslog/logrotate.d/syslog
+++ b/images/02-syslog/logrotate.d/syslog
@@ -1,0 +1,13 @@
+/var/log/messages
+/var/log/secure
+/var/log/syslog
+{
+	rotate 7
+	daily
+	delaycompress
+	missingok
+	sharedscripts
+	postrotate
+		/usr/bin/ros service kill --signal SIGHUP syslog
+	endscript
+}

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -161,6 +161,19 @@ rancher:
       read_only: true
       volumes:
       - /var/lib/docker:/var/lib/docker
+    logrotate:
+      image: {{.OS_REPO}}/os-logrotate:{{.VERSION}}{{.SUFFIX}}
+      command: /usr/sbin/logrotate -v /etc/logrotate.conf
+      labels:
+        io.rancher.os.createonly: "true"
+        io.rancher.os.scope: system
+        io.rancher.os.before: system-cron
+        cron.schedule: "@hourly"
+      uts: host
+      privileged: true
+      volumes_from:
+      - command-volumes
+      - system-volumes
     media-volumes:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: echo
@@ -215,7 +228,7 @@ rancher:
       - command-volumes
       - system-volumes
     syslog:
-      image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
+      image: {{.OS_REPO}}/os-syslog:{{.VERSION}}{{.SUFFIX}}
       command: rsyslogd -n
       labels:
         io.rancher.os.scope: system
@@ -227,6 +240,15 @@ rancher:
       volumes_from:
       - command-volumes
       - system-volumes
+    system-cron:
+      image: rancher/container-crontab:v0.1.0
+      labels:
+        io.rancher.os.scope: system
+      uts: host
+      privileged: true
+      restart: always
+      volumes:
+       - /var/run/system-docker.sock:/var/run/docker.sock
     system-volumes:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: echo
@@ -241,6 +263,7 @@ rancher:
       - /dev:/host/dev
       - /etc/docker:/etc/docker
       - /etc/hosts:/etc/hosts
+      - /etc/logrotate.d:/etc/logrotate.d
       - /etc/resolv.conf:/etc/resolv.conf
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt.rancher
       - /etc/selinux:/etc/selinux


### PR DESCRIPTION
Add basic log rotation with a `logrotate` system service, includes initial configs for Syslog and Docker with a daily rotation.

Addresses #1879 and #1885.

Cron calls `logrotate` on an hourly basis so that any files added to `logrotate.d/` via a `write_files` will be able to use hourly log rotation.

Cleared out the upstream `logrotate.conf` and `logrotate.d/*` to avoid any possibility of upstream config conflicts. This also makes the log rotation config potentially less confusing for newcomers as there will only be a single set of configs in the logrotate container, instead of all containers that inherit from os-base.

I'm not entirely sure which branch I should be creating a PR to, assuming the content is agreeable, let me know if I need to adjust or edit this PR.

Signed-off-by: Stephen Drake <stephen@xenolith.net>