### PR TITLE
Fix Drone CI

### DIFF
--- a/netconf/netconf_linux.go
+++ b/netconf/netconf_linux.go
@@ -176,14 +176,14 @@ func ApplyNetworkConfigs(netCfg *NetworkConfig, userSetHostname, userSetDNS bool
 
 	//apply network config
 	for _, link := range links {
-		applyOuter(link, netCfg, wg, userSetHostname, userSetDNS)
+		applyOuter(link, netCfg, &wg, userSetHostname, userSetDNS)
 	}
 	wg.Wait()
 
 	return err
 }
 
-func applyOuter(link netlink.Link, netCfg *NetworkConfig, wg sync.WaitGroup, userSetHostname, userSetDNS bool) {
+func applyOuter(link netlink.Link, netCfg *NetworkConfig, wg *sync.WaitGroup, userSetHostname, userSetDNS bool) {
 	log.Debugf("applyOuter(%V, %v)", userSetHostname, userSetDNS)
 	match, ok := findMatch(link, netCfg)
 	if !ok {

--- a/scripts/ci
+++ b/scripts/ci
@@ -9,10 +9,12 @@ echo TEST
 ./scripts/test
 echo VALIDATE
 ./scripts/validate
-echo PREPARE
-./scripts/prepare
-echo PACKAGE
-./scripts/package
-echo INTEGRATION-TEST
-./scripts/integration-test
+
+# Drone servers kernel too old, and the integration tests often time out
+#echo PREPARE
+#./scripts/prepare
+#echo PACKAGE
+#./scripts/package
+#echo INTEGRATION-TEST
+#./scripts/integration-test
 

--- a/scripts/release
+++ b/scripts/release
@@ -9,6 +9,14 @@ export INTEGRATION_TESTS=0
 
 ./scripts/ci
 
+# from scripts/ci
+echo PREPARE
+./scripts/prepare
+echo PACKAGE
+./scripts/package
+echo INTEGRATION-TEST
+./scripts/integration-test
+
 # make generated changelog
 lastrelease=$(hub release | grep -v rc | head -n1 | tr -d ' \r\n')
 git log --format="%s: %b" ${lastrelease}..${VERSION}  | grep "Merge pull" | sed 's/.*\(#.*\) from .*:\(.*\)/* \1: \2/g' > dist/artifacts/changelog.txt

--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -233,15 +233,15 @@ func (s *QemuSuite) TestNetworkCmds(c *C) {
 	s.RunQemuWithNetConsole(c, args...)
 	s.NetCheckOutput(c,
 		"pre_cmds\n"+
-		"pre_up lo\n"+
-		"post_up lo\n"+
-		"pre_up eth0\n"+
-		"post_up eth0\n"+
-		"pre_up eth1\n"+
-		"post_up eth1\n"+
-		"pre_up eth2\n"+
-		"post_up eth2\n"+
-		"post_cmds\n",
+			"pre_up lo\n"+
+			"post_up lo\n"+
+			"pre_up eth0\n"+
+			"post_up eth0\n"+
+			"pre_up eth1\n"+
+			"post_up eth1\n"+
+			"pre_up eth2\n"+
+			"post_up eth2\n"+
+			"post_cmds\n",
 		Equals,
 		"cat /var/log/net.log",
 	)


### PR DESCRIPTION
remove the full build and integration tests from Drone ci - they fail with "kernel is too old" - and fail too often with weird network issues.