### PR TITLE
WIP Add rancher.shutdown_timeout, if container stop takes too long force

### DIFF
--- a/cmd/power/shutdown.go
+++ b/cmd/power/shutdown.go
@@ -32,7 +32,7 @@ func Shutdown() {
 	app.Version = config.Version
 	app.Author = "Rancher Labs, Inc."
 	app.EnableBashCompletion = true
-	app.Action = shutdown
+	app.Action = shutdownCliAction
 	app.Flags = []cli.Flag{
 		//    --no-wall
 		//        Do not send wall message before halt, power-off,
@@ -182,7 +182,7 @@ func Reboot() {
 	reboot("reboot", false, syscall.LINUX_REBOOT_CMD_RESTART)
 }
 
-func shutdown(c *cli.Context) error {
+func shutdownCliAction(c *cli.Context) error {
 	// the shutdown command's default is poweroff
 	var powerCmd uint
 	powerCmd = syscall.LINUX_REBOOT_CMD_POWER_OFF
@@ -204,7 +204,7 @@ func shutdown(c *cli.Context) error {
 		// TODO: if there are more params, LOG them
 	}
 
-	reboot(c.App.Name, forceFlag, powerCmd)
-
-	return nil
+	err := reboot(c.App.Name, forceFlag, powerCmd)
+	log.Error(err)
+	return err
 }

--- a/config/schema.go
+++ b/config/schema.go
@@ -54,7 +54,8 @@ var schema = `{
         "resize_device": {"type": "string"},
         "sysctl": {"type": "object"},
         "restart_services": {"type": "array"},
-	"hypervisor_service": {"type": "boolean"}
+	      "hypervisor_service": {"type": "boolean"},
+        "shutdown_timeout:: {"type": "integer"}
       }
     },
 

--- a/config/types.go
+++ b/config/types.go
@@ -131,6 +131,7 @@ type RancherConfig struct {
 	Sysctl              map[string]string                         `yaml:"sysctl,omitempty"`
 	RestartServices     []string                                  `yaml:"restart_services,omitempty"`
 	HypervisorService   bool                                      `yaml:"hypervisor_service,omitempty"`
+	ShutdownTimeout     int                                       `yaml:shutdown_timeout`
 }
 
 type UpgradeConfig struct {

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -52,7 +52,8 @@
         "resize_device": {"type": "string"},
         "sysctl": {"type": "object"},
         "restart_services": {"type": "array"},
-	"hypervisor_service": {"type": "boolean"}
+	      "hypervisor_service": {"type": "boolean"},
+        "shutdown_timeout:: {"type": "integer"}
       }
     },
 


### PR DESCRIPTION
defaults to 60 seconds - but you can tune it using `rancher.shutdown_timeout`

This should help with issues like #1778 - giving a maximum time that RancherOS waits for containers to exit.

__TODO__: turns out this idea doesn't help for a "fun" case. if the container that doesn't complete shutdown is the console container, then the foreground timeout doesn't trigger, because sshd did quit as requested.