### PR TITLE
Merge pull request #2018 from SvenDowideit/update-rpi32-to-4.4.50

### DIFF
--- a/scripts/images/raspberry-pi-hypriot/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot/Dockerfile.dapper
@@ -14,8 +14,8 @@ COPY rootfs_arm.tar.gz /source/assets/rootfs_arm.tar.gz
 
 # see https://packagecloud.io/Hypriot/rpi/?filter=debs
 ENV URL=https://packagecloud.io/Hypriot/rpi/packages/debian/jessie/
-# 4.4.27-hypriotos-v7+
-ENV VER=20170119-202035
+# 4.4.50-hypriotos-v7+-1
+ENV VER=20170319-133405
 
 RUN curl -fL ${URL}/raspberrypi-kernel_${VER}_armhf.deb/download \
 	> /source/assets/kernel.deb


### PR DESCRIPTION
update rpi32 to 4.4.50
(cherry picked from commit 1e2e95070990e31d6767325b8a496ff20b62eb81)