### PR TITLE
Waiting a second between qemu tests seems to allow the network tests …

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -155,6 +155,7 @@ func (s *QemuSuite) NetCheckOutput(c *C, result string, check Checker, additiona
 
 func (s *QemuSuite) runQemu(c *C, args ...string) error {
 	c.Assert(s.qemuCmd, IsNil) // can't run 2 qemu's at once (yet)
+	time.Sleep(time.Second)
 	s.qemuCmd = exec.Command(s.runCommand, args...)
 	if os.Getenv("DEBUG") != "" {
 		s.qemuCmd.Stdout = os.Stdout


### PR DESCRIPTION
…to false fail less often

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>