### PR TITLE
Only add SSH configuration lines that are not set

### DIFF
--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -216,12 +216,12 @@ func modifySshdConfig() error {
 	sshdConfigString := string(sshdConfig)
 
 	for _, item := range []string{
-		"UseDNS no",
-		"PermitRootLogin no",
-		"ServerKeyBits 2048",
-		"AllowGroups docker",
+		"UseDNS ",
+		"PermitRootLogin ",
+		"ServerKeyBits ",
+		"AllowGroups ",
 	} {
-		match, err := regexp.Match("^"+item, sshdConfig)
+		match, err := regexp.Match("(?m)^"+item, sshdConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The current regex never matches, because `^` without the `m` flag is only the very beginning of the config string.  So these 4 config lines get added over and over, every time console init is run.

Separately, it's impossible to override them and have the option stick because it looks for the exact value.  So instead look for the presence of the (uncommented) keyword and assume if it's present the user probably wants that value.