### PR TITLE
Make the bootstrap phase logable

### DIFF
--- a/cmd/control/bootstrap.go
+++ b/cmd/control/bootstrap.go
@@ -7,16 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codegangsta/cli"
-
 	"github.com/rancher/os/config"
 	"github.com/rancher/os/log"
 	"github.com/rancher/os/util"
 )
 
-func bootstrapAction(c *cli.Context) error {
+func BootstrapMain() {
 	log.InitLogger()
-	log.Info("Running cloud-init-save")
 
 	log.Debugf("bootstrapAction")
 	if err := UdevSettle(); err != nil {
@@ -62,8 +59,6 @@ func bootstrapAction(c *cli.Context) error {
 	if err := UdevSettle(); err != nil {
 		log.Errorf("Failed to run udev settle: %v", err)
 	}
-
-	return nil
 }
 
 func mdadmScan() error {

--- a/cmd/control/cli.go
+++ b/cmd/control/cli.go
@@ -28,13 +28,6 @@ func Main() {
 
 	app.Commands = []cli.Command{
 		{
-			Name:            "bootstrap",
-			Hidden:          true,
-			HideHelp:        true,
-			SkipFlagParsing: true,
-			Action:          bootstrapAction,
-		},
-		{
 			Name:        "config",
 			ShortName:   "c",
 			Usage:       "configure settings",

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var entrypoints = map[string]func(){
 	"init":               osInit.MainInit,
 	"netconf":            network.Main,
 	"recovery":           control.AutologinMain,
+	"ros-bootstrap":      control.BootstrapMain,
 	"ros-sysinit":        sysinit.Main,
 	"system-docker":      systemdocker.Main,
 	"wait-for-docker":    wait.Main,

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -21,7 +21,7 @@ rancher:
   bootstrap:
     bootstrap:
       image: {{.OS_REPO}}/os-bootstrap:{{.VERSION}}{{.SUFFIX}}
-      command: ros bootstrap
+      command: ros-bootstrap
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system
@@ -33,6 +33,7 @@ rancher:
       - /lib/modules:/lib/modules
       - /lib/firmware:/lib/firmware
       - /usr/bin/ros:/usr/bin/ros:ro
+      - /usr/bin/ros:/usr/bin/ros-bootstrap:ro
       - /usr/share/ros:/usr/share/ros:ro
       - /var/lib/rancher:/var/lib/rancher:ro
       - /var/log:/var/log


### PR DESCRIPTION
I'm not sure this is the best way to do this - its effectivly a workaround for the `if os.Arg[0] == "ros"` then don't log the debug output.