### PR TITLE
Revert "Only add SSH configuration lines that are not set"

### DIFF
--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -216,12 +216,12 @@ func modifySshdConfig() error {
 	sshdConfigString := string(sshdConfig)
 
 	for _, item := range []string{
-		"UseDNS ",
-		"PermitRootLogin ",
-		"ServerKeyBits ",
-		"AllowGroups ",
+		"UseDNS no",
+		"PermitRootLogin no",
+		"ServerKeyBits 2048",
+		"AllowGroups docker",
 	} {
-		match, err := regexp.Match("(?m)^"+item, sshdConfig)
+		match, err := regexp.Match("^"+item, sshdConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Reverts rancher/os#2070

@vincent99 I should have run the tests on this - it kills the integration tests dead

I'll circle back to it later