### PR TITLE
Refactor a little so 'ros os list' also uses the configured proxy info

### DIFF
--- a/cmd/control/autologin.go
+++ b/cmd/control/autologin.go
@@ -73,7 +73,9 @@ func autologinAction(c *cli.Context) error {
 		// until I make time to read their source, lets just give us a way to get work done
 		loginBin = "bash"
 		args = append(args, "--login")
-		os.Setenv("PROMPT_COMMAND", `echo "[`+fmt.Sprintf("Recovery console %s@%s:${PWD}", user, cfg.Hostname)+`]"`)
+		if mode == "recovery" {
+			os.Setenv("PROMPT_COMMAND", `echo "[`+fmt.Sprintf("Recovery console %s@%s:${PWD}", user, cfg.Hostname)+`]"`)
+		}
 	} else {
 		loginBin = "login"
 		args = append(args, "-f", user)
@@ -91,7 +93,6 @@ func autologinAction(c *cli.Context) error {
 	//return syscall.Exec(loginBinPath, args, os.Environ())
 	cmd = exec.Command(loginBinPath, args...)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "SVEN", "MORE")
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -3,7 +3,6 @@ package control
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"runtime"
@@ -22,6 +21,7 @@ import (
 	"github.com/rancher/os/compose"
 	"github.com/rancher/os/config"
 	"github.com/rancher/os/docker"
+	"github.com/rancher/os/util/network"
 )
 
 type Images struct {
@@ -83,7 +83,6 @@ func osSubcommands() []cli.Command {
 	}
 }
 
-// TODO: this and the getLatestImage should probably move to utils/network and be suitably cached.
 func getImages() (*Images, error) {
 	upgradeURL, err := getUpgradeURL()
 	if err != nil {
@@ -108,12 +107,7 @@ func getImages() (*Images, error) {
 		u.RawQuery = q.Encode()
 		upgradeURL = u.String()
 
-		resp, err := http.Get(upgradeURL)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = network.LoadFromNetwork(upgradeURL)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/control/os.go
+++ b/cmd/control/os.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/os/compose"
 	"github.com/rancher/os/config"
 	"github.com/rancher/os/docker"
+	"github.com/rancher/os/util"
 	"github.com/rancher/os/util/network"
 )
 
@@ -104,6 +105,9 @@ func getImages() (*Images, error) {
 
 		q := u.Query()
 		q.Set("current", config.Version)
+		if hypervisor := util.GetHypervisor(); hypervisor == "" {
+			q.Set("hypervisor", hypervisor)
+		}
 		u.RawQuery = q.Encode()
 		upgradeURL = u.String()
 

--- a/config/cloudinit/datasource/url/url.go
+++ b/config/cloudinit/datasource/url/url.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/rancher/os/config/cloudinit/datasource"
 	"github.com/rancher/os/config/cloudinit/pkg"
+	"github.com/rancher/os/util/network"
 )
 
 type RemoteFile struct {
@@ -31,6 +32,7 @@ func NewDatasource(url string) *RemoteFile {
 }
 
 func (f *RemoteFile) IsAvailable() bool {
+	network.SetProxyEnvironmentVariables()
 	client := pkg.NewHTTPClient()
 	_, f.lastError = client.Get(f.url)
 	return (f.lastError == nil)

--- a/init/init.go
+++ b/init/init.go
@@ -452,6 +452,7 @@ func RunInit() error {
 		config.CfgFuncData{"load modules2", loadModules},
 		config.CfgFuncData{"set proxy env", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 			network.SetProxyEnvironmentVariables()
+
 			return cfg, nil
 		}},
 		config.CfgFuncData{"init SELinux", initializeSelinux},

--- a/init/init.go
+++ b/init/init.go
@@ -451,7 +451,7 @@ func RunInit() error {
 		}},
 		config.CfgFuncData{"load modules2", loadModules},
 		config.CfgFuncData{"set proxy env", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
-			network.SetProxyEnvironmentVariables(cfg)
+			network.SetProxyEnvironmentVariables()
 			return cfg, nil
 		}},
 		config.CfgFuncData{"init SELinux", initializeSelinux},

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -147,6 +147,10 @@ rancher:
         io.rancher.os.after: cloud-init-execute
         io.docker.compose.rebuild: always
         io.rancher.os.console: default
+      environment:
+      - HTTP_PROXY
+      - HTTPS_PROXY
+      - NO_PROXY
       net: host
       uts: host
       pid: host

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -77,6 +77,18 @@ func SetProxyEnvironmentVariables() {
 			log.Errorf("Unable to set NO_PROXY: %s", err)
 		}
 	}
+	if cfg.Rancher.Network.HTTPProxy != "" {
+		config.Set("rancher.environment.http_proxy", cfg.Rancher.Network.HTTPProxy)
+		config.Set("rancher.environment.HTTP_PROXY", cfg.Rancher.Network.HTTPProxy)
+	}
+	if cfg.Rancher.Network.HTTPSProxy != "" {
+		config.Set("rancher.environment.https_proxy", cfg.Rancher.Network.HTTPSProxy)
+		config.Set("rancher.environment.HTTPS_PROXY", cfg.Rancher.Network.HTTPSProxy)
+	}
+	if cfg.Rancher.Network.NoProxy != "" {
+		config.Set("rancher.environment.no_proxy", cfg.Rancher.Network.NoProxy)
+		config.Set("rancher.environment.NO_PROXY", cfg.Rancher.Network.NoProxy)
+	}
 }
 
 func LoadFromNetworkWithCache(location string) ([]byte, error) {

--- a/util/network/network.go
+++ b/util/network/network.go
@@ -57,7 +57,8 @@ func getServices(urls []string, key string) ([]string, error) {
 	return result, nil
 }
 
-func SetProxyEnvironmentVariables(cfg *config.CloudConfig) {
+func SetProxyEnvironmentVariables() {
+	cfg := config.LoadConfig()
 	if cfg.Rancher.Network.HTTPProxy != "" {
 		err := os.Setenv("HTTP_PROXY", cfg.Rancher.Network.HTTPProxy)
 		if err != nil {
@@ -78,14 +79,16 @@ func SetProxyEnvironmentVariables(cfg *config.CloudConfig) {
 	}
 }
 
-func loadFromNetwork(location string) ([]byte, error) {
+func LoadFromNetworkWithCache(location string) ([]byte, error) {
 	bytes := cacheLookup(location)
 	if bytes != nil {
 		return bytes, nil
 	}
+	return LoadFromNetwork(location)
+}
 
-	cfg := config.LoadConfig()
-	SetProxyEnvironmentVariables(cfg)
+func LoadFromNetwork(location string) ([]byte, error) {
+	SetProxyEnvironmentVariables()
 
 	var err error
 
@@ -116,7 +119,7 @@ func LoadResource(location string, network bool) ([]byte, error) {
 		if !network {
 			return nil, ErrNoNetwork
 		}
-		return loadFromNetwork(location)
+		return LoadFromNetworkWithCache(location)
 	} else if strings.HasPrefix(location, "/") {
 		return ioutil.ReadFile(location)
 	}


### PR DESCRIPTION
for #1914 

also set http_proxy env vars for consoles.

I'm having issues with `wget` in the `default` console still, but it works with the proxy in the debian console - I might leave that for the future tho.


**Important note** if you need to `sudo`, use `sudo -i` so you get the `/etc/profile.d/*` env, in which the proxy env is set.
