### PR TITLE
rpi64 linux kernel 4.9.50

### DIFF
--- a/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
@@ -13,11 +13,11 @@ RUN mkdir -p /source/assets
 COPY rootfs_arm64.tar.gz /source/assets/rootfs_arm64.tar.gz
 
 ENV URL=https://github.com/SvenDowideit/rpi64-kernel/releases/download
-ENV VER=v20170626-014036
+ENV VER=v20170916-110614
 
-RUN curl -fL ${URL}/${VER}/4.9.34-bee42-v8.tar.gz > /source/assets/kernel.tar.gz
+RUN curl -fL ${URL}/${VER}/4.9.50-bee42-v8.tar.gz > /source/assets/kernel.tar.gz
 RUN curl -fL ${URL}/${VER}/bootfiles.tar.gz > /source/assets/bootfiles.tar.gz
-RUN curl -fL https://github.com/SvenDowideit/rpi-bootloader/releases/download/v20170622-085322/rpi-bootloader.tar.gz > /source/assets/rpi-bootfiles.tar.gz
+RUN curl -fL https://github.com/SvenDowideit/rpi-bootloader/releases/download/v20170916-104016/rpi-bootloader.tar.gz > /source/assets/rpi-bootfiles.tar.gz
 
 #ENV RPI_URL=https://github.com/raspberrypi/firmware/raw/master/boot
 #RUN curl -fL ${RPI_URL}/bootcode.bin > /source/assets/bootcode.bin


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

(test build using the 1.0.0 arm64 rootfs)

- 150 seconds to first boot (with no network?)
- 90 seconds for second boot without network.
- 70 seconds for third boot with network

need to find and kill the 20 seconds :D

the initial boot time should improve dramatically in 1.2, as we shouldn't need to do the really lengthy `docker load`
