### PR TITLE
Fix error typo in loadConsoleService func

### DIFF
--- a/compose/reload.go
+++ b/compose/reload.go
@@ -106,7 +106,7 @@ func projectReload(p *project.Project, useNetwork *bool, loadConsole bool, envir
 
 		if loadConsole {
 			if err := loadConsoleService(cfg, p); err != nil {
-				log.Errorf("Failed to load gancher.console=(%s): %v", cfg.Rancher.Console, err)
+				log.Errorf("Failed to load rancher.console=(%s): %v", cfg.Rancher.Console, err)
 			}
 		}
 


### PR DESCRIPTION
Replace error text from "Failed to load **g**ancher.console" to "Failed to load **r**ancher.console"