### PR TITLE
Fix format 'verbs' for error

### DIFF
--- a/cmd/control/install.go
+++ b/cmd/control/install.go
@@ -237,14 +237,14 @@ func runInstall(image, installType, cloudConfig, device, partition, statedir, ka
 
 		if _, err := os.Stat("/dist/initrd-" + config.Version); os.IsNotExist(err) {
 			if err = mountBootIso(); err != nil {
-				log.Debugf("mountBootIso error %s", err)
+				log.Debugf("mountBootIso error %v", err)
 			} else {
 				log.Infof("trying to load /bootiso/rancheros/installer.tar.gz")
 				if _, err := os.Stat("/bootiso/rancheros/"); err == nil {
 					cmd := exec.Command("system-docker", "load", "-i", "/bootiso/rancheros/installer.tar.gz")
 					cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 					if err := cmd.Run(); err != nil {
-						log.Infof("failed to load images from /bootiso/rancheros: %s", err)
+						log.Infof("failed to load images from /bootiso/rancheros: %v", err)
 					} else {
 						log.Infof("Loaded images from /bootiso/rancheros/installer.tar.gz")
 

--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -69,7 +69,7 @@ func ApplyNetworkConfig(cfg *config.CloudConfig) {
 	}
 
 	resolve, err := ioutil.ReadFile("/etc/resolv.conf")
-	log.Debugf("Resolve.conf == [%s], %s", resolve, err)
+	log.Debugf("Resolve.conf == [%s], %v", resolve, err)
 
 	log.Infof("Apply Network Config SyncHostname")
 	if err := hostname.SyncHostname(); err != nil {

--- a/cmd/sysinit/sysinit.go
+++ b/cmd/sysinit/sysinit.go
@@ -1,17 +1,18 @@
 package sysinit
 
 import (
-	initPkg "github.com/rancher/os/init"
-	"github.com/rancher/os/log"
 	"io/ioutil"
 	"os"
+
+	initPkg "github.com/rancher/os/init"
+	"github.com/rancher/os/log"
 )
 
 func Main() {
 	log.InitLogger()
 
 	resolve, err := ioutil.ReadFile("/etc/resolv.conf")
-	log.Infof("2Resolv.conf == [%s], %s", resolve, err)
+	log.Infof("Resolv.conf == [%s], %v", resolve, err)
 	log.Infof("Exec %v", os.Args)
 
 	if err := initPkg.SysInit(); err != nil {

--- a/config/data_funcs.go
+++ b/config/data_funcs.go
@@ -26,7 +26,7 @@ func ChainCfgFuncs(cfg *CloudConfig, cfgFuncs CfgFuncs) (*CloudConfig, error) {
 		}
 		var err error
 		if cfg, err = cfgFunc(cfg); err != nil {
-			log.Errorf("Failed [%d/%d] %s: %s", i, len, name, err)
+			log.Errorf("Failed [%d/%d] %s: %v", i, len, name, err)
 			return cfg, err
 		}
 		log.Debugf("[%d/%d] Done %s", i, len, name)

--- a/dfs/scratch.go
+++ b/dfs/scratch.go
@@ -75,7 +75,7 @@ func createOptionalMounts(mounts ...[]string) {
 		log.Debugf("Mounting %s %s %s %s", mount[0], mount[1], mount[2], mount[3])
 		err := util.Mount(mount[0], mount[1], mount[2], mount[3])
 		if err != nil {
-			log.Debugf("Unable to mount %s %s %s %s: %s", mount[0], mount[1], mount[2], mount[3], err)
+			log.Debugf("Unable to mount %s %s %s %s: %v", mount[0], mount[1], mount[2], mount[3], err)
 		}
 	}
 }
@@ -358,7 +358,7 @@ ff02::2    ip6-allrouters
 
 	if len(cfg.DNSConfig.Nameservers) != 0 {
 		resolve, err := ioutil.ReadFile("/etc/resolv.conf")
-		log.Debugf("Resolve.conf == [%s], err", resolve, err)
+		log.Debugf("Resolve.conf == [%s], %v", resolve, err)
 
 		if err != nil {
 			log.Infof("scratch Writing empty resolv.conf (%v) %v", []string{}, []string{})

--- a/log/showuserlog.go
+++ b/log/showuserlog.go
@@ -64,7 +64,7 @@ func (hook *ShowuserlogHook) NotUsedYetLogSystemReady() error {
 	if hook.syslogHook == nil {
 		h, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
 		if err != nil {
-			logrus.Debugf("error creating SyslogHook: %s", err)
+			logrus.Debugf("error creating SyslogHook: %v", err)
 			return err
 		}
 		hook.syslogHook = h


### PR DESCRIPTION
Replace '%s' with '%v' to avoid lines like below in log

level=debug msg="Resolve.conf == [], **err%!(EXTRA <nil>)**"