### PR TITLE
Fix user-data for ec2 metadata source

### DIFF
--- a/config/cloudinit/datasource/metadata/ec2/metadata.go
+++ b/config/cloudinit/datasource/metadata/ec2/metadata.go
@@ -30,7 +30,7 @@ import (
 const (
 	DefaultAddress = "http://169.254.169.254/"
 	apiVersion     = "latest/"
-	userdataPath   = apiVersion + "user-data/"
+	userdataPath   = apiVersion + "user-data"
 	metadataPath   = apiVersion + "meta-data/"
 )
 


### PR DESCRIPTION
The commit change the endpoint url of the ec2 metadata service for the user-data. By default the endpoint is reachable at "http://169.254.169.254/latest/user-data" without the slash "/" at the end.

For this reason see the ec2 metadata service documentation: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

It is also fixed in the coreOS repository, the source of this file:
https://github.com/coreos/coreos-cloudinit/blob/master/datasource/metadata/ec2/metadata.go