### PR TITLE
Use GetRetry when detecting if url is available

### DIFF
--- a/config/cloudinit/datasource/url/url.go
+++ b/config/cloudinit/datasource/url/url.go
@@ -34,7 +34,7 @@ func NewDatasource(url string) *RemoteFile {
 func (f *RemoteFile) IsAvailable() bool {
 	network.SetProxyEnvironmentVariables()
 	client := pkg.NewHTTPClient()
-	_, f.lastError = client.Get(f.url)
+	_, f.lastError = client.GetRetry(f.url)
 	return (f.lastError == nil)
 }
 


### PR DESCRIPTION
For `client.Get`, its default timeout is 10s. if there is more than one interface run DHCP when booting by iPXE, multiple DHCP interferences may result in an inability to access the URL within 10s.

`GetRetry` will try again 15 times, wait for about 150s.
That is long enough to complete all DHCP, `cloud-init-save` will execute normally.

https://github.com/rancher/os/issues/2144
https://github.com/rancher/os/issues/2199