### PR TITLE
Reduce the memory consumption at startup

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -35,7 +35,8 @@ RUN echo "Acquire::http { Proxy \"$APTPROXY\"; };" >> /etc/apt/apt.conf.d/01prox
         vim \
         wget \
         xorriso \
-	telnet
+        xz-utils \
+        telnet
 
 ########## Dapper Configuration #####################
 

--- a/scripts/tar-images
+++ b/scripts/tar-images
@@ -13,5 +13,5 @@ for i in $IMAGES; do
 done
 
 echo "tar-images: docker save ${IMAGES} > build/images.tar"
-docker save ${IMAGES} > build/images.tar
+docker save ${IMAGES} | xz > build/images.tar
 echo "tar-images: DONE"


### PR DESCRIPTION
Offline image is automatically loaded when the system boots.
When the system memory is not large enough (such as 1G), will lead to
kernel panic.

https://github.com/rancher/os/issues/2242