### PR TITLE
cmd/power: Another shutdown command fix

### DIFF
--- a/cmd/power/shutdown.go
+++ b/cmd/power/shutdown.go
@@ -27,7 +27,7 @@ func Shutdown() {
 	log.InitLogger()
 	app := cli.NewApp()
 
-	app.Name = os.Args[0]
+	app.Name = filepath.Base(os.Args[0])
 	app.Usage = fmt.Sprintf("%s RancherOS\nbuilt: %s", app.Name, config.BuildDate)
 	app.Version = config.Version
 	app.Author = "Rancher Labs, Inc."


### PR DESCRIPTION
It looks like some arguments for shutdown/halt/poweroff have been moved
to a conditional block that works off of how the command was actually
called. However, this value is derived from argv 0, without any sort of
normalization to make sure it matches the relative commands used to
determine how arguments are handled.

This has particular implications when power management commands are
called via absolute commands, as for example in the case of
`open-vm-tools` which calls `/sbin/shutdown -h now` specifically when
shutting down a system.

This corrects the situation by passing argv 0 through `filepath.Base`
before operating on it.