### PR TITLE
Add decode logic for writefiles

### DIFF
--- a/cmd/cloudinitexecute/cloudinitexecute.go
+++ b/cmd/cloudinitexecute/cloudinitexecute.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	rancherConfig "github.com/rancher/os/config"
+	"github.com/rancher/os/config/cloudinit/config"
 	"github.com/rancher/os/config/cloudinit/system"
 	"github.com/rancher/os/docker"
 	"github.com/rancher/os/log"
@@ -123,6 +124,14 @@ func WriteFiles(cfg *rancherConfig.CloudConfig, container string) {
 		if fileContainer != container {
 			continue
 		}
+
+		content, err := config.DecodeContent(file.File.Content, file.File.Encoding)
+		if err != nil {
+			continue
+		}
+
+		file.File.Content = string(content)
+		file.File.Encoding = ""
 
 		f := system.File{
 			File: file.File,


### PR DESCRIPTION
Relate to #2284 

CloudInit WriteFiles failed when user define user-data with encoding like this 
```yaml
#cloud-config
write_files:
 - path: /home/rancher/vpn_server.config
   permissions: "0644"
   owner: root
   encoding: "gzip+base64"
   content: $(content in b64/gzip)
 ```
Reason:
  In CoreOS cloudinit, user-data are parsed by `ParseUserData` function which contain a `cc.Decode()` logic in it.
  Our repo have the same function with coreOS `ParseUserData` but is not called anywhere.So I extracted the main logical part of it and added it here to solve the `WriteFiles` problem, ensure that the impact was minimized.

https://github.com/coreos/coreos-cloudinit/blob/master/coreos-cloudinit.go#L232
https://github.com/coreos/coreos-cloudinit/blob/3c68e2e67d2ea077e2b79383c0ad313770c62ca2/initialize/user_data.go#L44