### PR TITLE
Add parameters while loading kernel modules

### DIFF
--- a/init/init.go
+++ b/init/init.go
@@ -60,7 +60,9 @@ func loadModules(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 		}
 
 		log.Debugf("Loading module %s", module)
-		cmd := exec.Command("modprobe", module)
+		// split module and module parameters
+		cmdParam := strings.SplitN(module, " ", -1)
+		cmd := exec.Command("modprobe", cmdParam...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
We could add rancher.modules with parameters now. 
Here is an example:
 `sudo ros config set rancher.modules "['nbd nbds_max=1024']"`


https://github.com/rancher/os/issues/2295