### PR TITLE
enhance preload image process for system-scope services

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -55,7 +55,8 @@ var schema = `{
         "sysctl": {"type": "object"},
         "restart_services": {"type": "array"},
 	"hypervisor_service": {"type": "boolean"},
-        "shutdown_timeout": {"type": "integer"}
+        "shutdown_timeout": {"type": "integer"},
+	"preload_wait": {"type": "boolean"}
       }
     },
 

--- a/config/types.go
+++ b/config/types.go
@@ -137,6 +137,7 @@ type RancherConfig struct {
 	RestartServices     []string                                  `yaml:"restart_services,omitempty"`
 	HypervisorService   bool                                      `yaml:"hypervisor_service,omitempty"`
 	ShutdownTimeout     int                                       `yaml:"shutdown_timeout,omitempty"`
+	PreloadWait         bool                                      `yaml:"preload_wait,omitempty"`
 }
 
 type UpgradeConfig struct {

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -53,7 +53,8 @@
         "sysctl": {"type": "object"},
         "restart_services": {"type": "array"},
 	"hypervisor_service": {"type": "boolean"},
-	"shutdown_timeout": {"type": "integer"}
+	"shutdown_timeout": {"type": "integer"},
+	"preload_wait": {"type": "boolean"}
       }
     },
 


### PR DESCRIPTION
enhance preload image process for system-scope services. 
When the user wants to make sure that the system-scope service starts after the preload process, it can be done as follows.
```
rancher:
  preload_wait: true
```

Relate to #2297 #1698