### PR TITLE
Added Raspberry Pi 3B+ support

### DIFF
--- a/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
@@ -13,7 +13,7 @@ RUN mkdir -p /source/assets
 COPY rootfs_arm64.tar.gz /source/assets/rootfs_arm64.tar.gz
 
 ENV URL=https://github.com/DieterReuter/rpi64-kernel/releases/download
-ENV VER=v20180319-130037
+ENV VER=v20180426-171616
 
 RUN curl -fL ${URL}/${VER}/4.9.80-hypriotos-v8.tar.gz > /source/assets/kernel.tar.gz
 RUN curl -fL ${URL}/${VER}/bootfiles.tar.gz > /source/assets/bootfiles.tar.gz


### PR DESCRIPTION
Updated to latest version of rpi64-kernel which contains support for Raspberry Pi 3B+

Fixes #2327