### PR TITLE
Skip VLAN interfaces for MAC address matching in netconf.findMatch

### DIFF
--- a/netconf/netconf_linux.go
+++ b/netconf/netconf_linux.go
@@ -114,8 +114,8 @@ func findMatch(link netlink.Link, netCfg *NetworkConfig) (InterfaceConfig, bool)
 				continue
 			}
 
-			// Don't match mac address of the bond because it is the same as the slave
-			if bytes.Compare(haAddr, link.Attrs().HardwareAddr) == 0 && link.Attrs().Name != netConf.Bond {
+			// Don't match mac address of a bond or VLAN interface because it is the same address as the slave or parent.
+			if bytes.Compare(haAddr, link.Attrs().HardwareAddr) == 0 && link.Attrs().Name != netConf.Bond && link.Type() != "vlan" {
 				// MAC address match is used over all other matches
 				return netConf, true
 			}


### PR DESCRIPTION
Fixes #1551 by not matching on MAC address if the interface type is a vlan. This also fixes vlan interfaces being created from vlan interfaces, eg. `eth0.100.100`.

There is a more pedantic way of doing this based on looking at the Vlans field in netConf, but I can't think of any configuration where this would be better than simply looking for MAC address matching and interface type being `vlan`. However, since I already did the work I'll include it here:

```
			if bytes.Compare(haAddr, link.Attrs().HardwareAddr) == 0 {
				if link.Type() == "vlan" && netConf.Vlans != "" {
					vlanDefs, err := ParseVlanDefinitions(netConf.Vlans)
					if err != nil {
						log.Errorf("Failed to parse VLANs definitions for %s: %v", netConf.Match[4:], err)
						continue
					}

					// Search for the link in the VLAN definitions of the netConf. Don't match VLAN interfaces since
					// the mac address is the same as the parent interface.
					for _, vlanDef := range vlanDefs {
						if vlanDef.Name == link.Attrs().Name || strings.HasSuffix(link.Attrs().Name, strconv.Itoa(vlanDef.ID)) {
							foundParent = true
						}
					}
				}

				// Don't match mac address of the bond because it is the same as the slave interfaces
				if link.Attrs().Name == netConf.Bond {
					foundParent = true
				}

				if !foundParent {
					// MAC address match is used over all other matches below
					return netConf, true
				}
			}
```