### PR TITLE
Modify the acquisition of container_name

### DIFF
--- a/trash.conf
+++ b/trash.conf
@@ -14,7 +14,7 @@ github.com/docker/docker b40c87254f587af7cad8e8128f061a2a7f367343 https://github
 github.com/docker/engine-api v0.3.3
 github.com/docker/go-connections v0.2.0
 github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
-github.com/docker/libcompose b9f88a071f78d49293a8f31ae0d2e339085fd0d7 https://github.com/rancher/libcompose.git
+github.com/docker/libcompose c598536dc130c03c419d74f4c66c9dd0f728338d https://github.com/wchao1241/libcompose.git
 github.com/docker/libnetwork v0.5.6
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/docker/machine 4a8e93ac9bc2ced1c3bc4a43c03fdaa1c2749205

--- a/vendor/github.com/docker/libcompose/docker/service.go
+++ b/vendor/github.com/docker/libcompose/docker/service.go
@@ -94,15 +94,17 @@ func (s *Service) collectContainers(ctx context.Context) ([]*Container, error) {
 		numberLabel := container.Labels[labels.NUMBER.Str()]
 		name := strings.SplitAfter(container.Names[0], "/")
 		if numberLabel == "" {
-			result = append(result, NewContainer(client, name[1], 1, s))
+			result = append(result, NewContainer(client, name[len(name)-1], 1, s))
 			return result, nil
 		}
 		containerNumber, err := strconv.Atoi(numberLabel)
 		if err != nil {
 			return nil, err
 		}
-		// Compose add "/" before name, so Name[1] will store actaul name.
-		result = append(result, NewContainer(client, name[1], containerNumber, s))
+		// Compose add "/" before ordinary container name,
+		// Compose add "/primary-container-name/" before Linked container name,
+		// so use Name[len(name)-1] to store actaul name
+		result = append(result, NewContainer(client, name[len(name)-1], containerNumber, s))
 	}
 
 	return result, nil


### PR DESCRIPTION
fix  issue  [#2334](https://github.com/rancher/os/issues/2334)

It is different to get linked container name and ordinary container name, the format of ordinary container name is "/ordinary-container-name", the format of linked container name is "/primary-container-name/linked-container-name".so I modify the acquisition of container-name.