### PR TITLE
Retrieve cloud-config from providers before "mount and bootstrap"

### DIFF
--- a/init/init.go
+++ b/init/init.go
@@ -317,15 +317,6 @@ func RunInit() error {
 
 			return config.LoadConfig(), nil
 		}},
-		config.CfgFuncData{"mount and bootstrap", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
-			var err error
-			cfg, shouldSwitchRoot, err = tryMountAndBootstrap(cfg)
-
-			if err != nil {
-				return nil, err
-			}
-			return cfg, nil
-		}},
 		config.CfgFuncData{"cloud-init", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 			cfg.Rancher.CloudInit.Datasources = config.LoadConfigWithPrefix(state).Rancher.CloudInit.Datasources
 			hypervisor = util.GetHypervisor()
@@ -352,6 +343,15 @@ func RunInit() error {
 			log.AddRSyslogHook()
 
 			return config.LoadConfig(), nil
+		}},
+		config.CfgFuncData{"mount and bootstrap", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
+			var err error
+			cfg, shouldSwitchRoot, err = tryMountAndBootstrap(cfg)
+
+			if err != nil {
+				return nil, err
+			}
+			return cfg, nil
 		}},
 		config.CfgFuncData{"read cfg and log files", func(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 			filesToCopy := []string{


### PR DESCRIPTION
Fist retrieve the cloud-init config from the different provider before calling “mount and bootstrap”. This allows to provide the “autoformat” and mount settings (label of device to mount) through a cloud-init provider, e.g. vmware guestinfo.