### PR TITLE
Optimized image loading to reduce memory footprint and boot time

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -21,7 +21,8 @@ const (
 	SystemDockerHost = "unix:///var/run/system-docker.sock"
 	DockerHost       = "unix:///var/run/docker.sock"
 	ImagesPath       = "/usr/share/ros"
-	ImagesPattern    = "images*.tar"
+	InitImages       = "images-init.tar"
+	SystemImages     = "images-system.tar"
 	ModulesArchive   = "/modules.tar"
 	Debug            = false
 	SystemDockerLog  = "/var/log/system-docker.log"

--- a/init/bootstrap.go
+++ b/init/bootstrap.go
@@ -68,7 +68,7 @@ func bootstrap(cfg *config.CloudConfig) error {
 
 	_, err = config.ChainCfgFuncs(cfg,
 		[]config.CfgFuncData{
-			config.CfgFuncData{"bootstrap loadImages", loadImages},
+			config.CfgFuncData{"bootstrap loadImages", loadBootstrapImages},
 			config.CfgFuncData{"bootstrap Services", bootstrapServices},
 		})
 	return err
@@ -84,7 +84,7 @@ func runCloudInitServices(cfg *config.CloudConfig) error {
 
 	_, err = config.ChainCfgFuncs(cfg,
 		[]config.CfgFuncData{
-			config.CfgFuncData{"cloudinit loadImages", loadImages},
+			config.CfgFuncData{"cloudinit loadImages", loadBootstrapImages},
 			config.CfgFuncData{"cloudinit Services", runCloudInitServiceSet},
 		})
 	return err

--- a/init/recovery.go
+++ b/init/recovery.go
@@ -87,7 +87,7 @@ func recovery(initFailure error) {
 
 	_, err = config.ChainCfgFuncs(&recoveryConfig,
 		[]config.CfgFuncData{
-			config.CfgFuncData{"loadImages", loadImages},
+			config.CfgFuncData{"loadSystemImages", loadSystemImages},
 			config.CfgFuncData{"recovery console", recoveryServices},
 		})
 	if err != nil {

--- a/scripts/layout-initrd
+++ b/scripts/layout-initrd
@@ -7,7 +7,7 @@ mkdir -p ${INITRD_DIR}/usr/{etc,lib,bin,share/ros}
 ./scripts/template
 
 cp -rf assets/selinux          ${INITRD_DIR}/usr/etc
-cp build/images.tar            ${INITRD_DIR}/usr/share/ros/
+cp build/images*.tar           ${INITRD_DIR}/usr/share/ros/
 cp bin/ros                     ${INITRD_DIR}/usr/bin/
 ln -s usr/bin/ros              ${INITRD_DIR}/init
 ln -s bin                      ${INITRD_DIR}/usr/sbin

--- a/scripts/package-rootfs
+++ b/scripts/package-rootfs
@@ -12,24 +12,28 @@ PREPOP_DIR=${IMAGE_CACHE}/var/lib/system-docker
 INITRD_DIR=${BUILD}/initrd
 ARTIFACTS=$(pwd)/dist/artifacts
 INITRD=${ARTIFACTS}/initrd
+INIT_IMAGES="images-init.tar"
+SYSTEM_IMAGES="images-system.tar"
 
 mkdir -p ${ARTIFACTS} ${PREPOP_DIR}
 
 if [ "$(docker info | grep 'Storage Driver: ' | sed 's/Storage Driver: //')" != "overlay" ]; then
-    echo Overlay storage driver is required to prepackage exploded images
-    echo packaging images.tar instead
+    echo Overlay storage driver is require to prepackage exploded images
+    echo packaging image tar archives instead
     tar czf ${ARTIFACTS}/rootfs${SUFFIX}.tar.gz --exclude lib/modules --exclude lib/firmware -C ${INITRD_DIR} .
     exit 0
 fi
 
 DFS=$(docker run -d --privileged -v /lib/modules/$(uname -r):/lib/modules/$(uname -r) ${DFS_IMAGE}${SUFFIX} ${DFS_ARGS})
 trap "docker rm -fv ${DFS_ARCH} ${DFS}" EXIT
-docker exec -i ${DFS} docker load < ${INITRD_DIR}/usr/share/ros/images.tar
+docker exec -i ${DFS} docker load < ${INITRD_DIR}/usr/share/ros/${INIT_IMAGES}
+docker exec -i ${DFS} docker load < ${INITRD_DIR}/usr/share/ros/${SYSTEM_IMAGES}
 docker stop ${DFS}
 docker run --rm --volumes-from=${DFS} --entrypoint /bin/bash rancher/os-base -c "tar -c -C /var/lib/docker ./image" | tar -x -C ${PREPOP_DIR}
 docker run --rm --volumes-from=${DFS} --entrypoint /bin/bash rancher/os-base -c "tar -c -C /var/lib/docker ./overlay" | tar -x -C ${PREPOP_DIR}
 
-tar -cf ${ARTIFACTS}/rootfs${SUFFIX}.tar --exclude usr/share/ros/images.tar  --exclude lib/modules --exclude lib/firmware -C ${INITRD_DIR} .
+tar -cf ${ARTIFACTS}/rootfs${SUFFIX}.tar --exclude usr/share/ros/${INIT_IMAGES} --exclude usr/share/ros/${SYSTEM_IMAGES} --exclude lib/modules --exclude
+lib/firmware -C ${INITRD_DIR} .
 tar -rf ${ARTIFACTS}/rootfs${SUFFIX}.tar -C ${IMAGE_CACHE} .
 rm -f ${ARTIFACTS}/rootfs${SUFFIX}.tar.gz
 gzip ${ARTIFACTS}/rootfs${SUFFIX}.tar

--- a/scripts/release
+++ b/scripts/release
@@ -7,7 +7,7 @@ export REPO_VERSION=$VERSION
 if [[ -n "$DIRTY" || -z "$GIT_TAG" ]]; then
     export REPO_VERSION=master
 fi
-export COMPRESS="xz --format=lzma -9 --memlimit-compress=80% -e"
+export COMPRESS="gzip -9"
 
 ./scripts/ci
 

--- a/scripts/tar-images
+++ b/scripts/tar-images
@@ -1,29 +1,48 @@
 #!/bin/bash
 set -ex
 
+INIT_DEP="rancher/os-bootstrap"
+SHARED_DEP="rancher/os-base"
+INIT_IMAGES_DST="build/images-init.tar"
+SYSTEM_IMAGES_DST="build/images-system.tar"
+
 cd $(dirname $0)/..
 
 IMAGES=$(bin/host_ros c images -i build/initrd/usr/share/ros/os-config.yml)
-echo "tar-image: IMAGES=$IMAGES"
-for i in $IMAGES; do
+INIT_IMAGES=""
+SYSTEM_IMAGES=""
+for i in ${IMAGES}; do
     echo "tar-image: pull($i)"
     if [ "${FORCE_PULL}" = "1" ] || ! docker inspect $i >/dev/null 2>&1; then
-        docker pull $i
+        docker pull ${i}
+    fi
+
+    if [ "${i%%:*}" != "$INIT_DEP" ] ; then
+        SYSTEM_IMAGES="$SYSTEM_IMAGES $i"
+    fi
+
+    if [ "${i%%:*}" = "$INIT_DEP" ] || [ "${i%%:*}" = "$SHARED_DEP" ] ; then
+        INIT_IMAGES="$INIT_IMAGES $i"
     fi
 done
 
 if [ -e ".make-vmware" ]; then
     docker pull rancher/os-openvmtools:${OPEN_VMTOOLS_VERSION}
-    IMAGES="$IMAGES rancher/os-openvmtools:${OPEN_VMTOOLS_VERSION}"
+    SYSTEM_IMAGES="$SYSTEM_IMAGES rancher/os-openvmtools:${OPEN_VMTOOLS_VERSION}"
 fi
 
-echo "tar-images: docker save ${IMAGES}"
+echo "tar-image: SYSTEM_IMAGES=$SYSTEM_IMAGES"
+echo "tar-image: INIT_IMAGES=$INIT_IMAGES"
+
 if [ "$COMPRESS" == "" ]; then
-    docker save ${IMAGES} | gzip > build/images.tar
+    ARCHIVE_CMD="gzip"
 else
     # system-docker can not load images which compressed by xz with a compression level of 9
     # decompression consumes more memory if using level 9
     # the default compression level for xz is 6
-    docker save ${IMAGES} | xz -6 -e > build/images.tar
+    ARCHIVE_CMD="xz -4 -e"
 fi
+
+docker save ${INIT_IMAGES} | ${ARCHIVE_CMD} > ${INIT_IMAGES_DST}
+docker save ${SYSTEM_IMAGES} | ${ARCHIVE_CMD} > ${SYSTEM_IMAGES_DST}
 echo "tar-images: DONE"


### PR DESCRIPTION
Preliminary testing (1.4.x branch) suggests that these changes reduce hardware memory requirements as follows:

Platform | RAM requirement
-- | --
Baremetal | 768MB ~~1280MB~~  (1024MB to run installer)
VirtualBox | 768MB ~~1280MB~~ (1024MB to run installer)
VMWare | 768MB ~~1280MB~~ (installed to disk) 1024MB ~~2048MB~~ (docker-machine) 

Seems to boot much faster:

```
RancherOS Boot Time*      v1.4 -> dev build
==================================================
VMware Fusion  2GB 2vPU      87sec -> 35sec
==================================================
VirtualBox     2GB 2vCPU     48sec -> 31sec
==================================================
VirtualBox     3GB 2vCPU     49sec -> 27sec
==================================================

*time from kernel starting to "RancherOS started" log message
```

Caveats? ISO file size increases approx. by 30MB.

![screen shot 2018-09-10 at 04 14 10](https://user-images.githubusercontent.com/3813921/45297731-9b049480-b506-11e8-9b4e-7f5dffc27e90.png)

