### PR TITLE
cloudinitsave: Fix typo in log output

### DIFF
--- a/cmd/cloudinitsave/cloudinitsave.go
+++ b/cmd/cloudinitsave/cloudinitsave.go
@@ -74,7 +74,7 @@ func saveCloudConfig() error {
 	log.Debugf("init: SaveCloudConfig(pre ApplyNetworkConfig): %#v", cfg.Rancher.Network)
 	network.ApplyNetworkConfig(cfg)
 
-	log.Infof("datasources that will be consided: %#v", cfg.Rancher.CloudInit.Datasources)
+	log.Infof("datasources that will be considered: %#v", cfg.Rancher.CloudInit.Datasources)
 	dss := getDatasources(cfg.Rancher.CloudInit.Datasources)
 	if len(dss) == 0 {
 		log.Errorf("currentDatasource - none found")


### PR DESCRIPTION
This PR fixes a typo in a log message.