### PR TITLE
Support vSphere network protocol profiles

### DIFF
--- a/config/cloudinit/datasource/vmware/vmware.go
+++ b/config/cloudinit/datasource/vmware/vmware.go
@@ -77,10 +77,24 @@ func (v VMWare) FetchMetadata() (metadata datasource.Metadata, err error) {
 		}
 		metadata.NetworkConfig.DNS.Nameservers = append(metadata.NetworkConfig.DNS.Nameservers, val)
 	}
+	dnsServers, _ := v.read("dns.servers")
+	for _, val := range strings.Split(dnsServers, ",") {
+		if val == "" {
+			break
+		}
+		metadata.NetworkConfig.DNS.Nameservers = append(metadata.NetworkConfig.DNS.Nameservers, val)
+	}
 
 	for i := 0; ; i++ {
 		//if domain := saveConfig("dns.domain.%d", i); domain == "" {
 		val, _ := v.read("dns.domain.%d", i)
+		if val == "" {
+			break
+		}
+		metadata.NetworkConfig.DNS.Search = append(metadata.NetworkConfig.DNS.Search, val)
+	}
+	dnsDomains, _ := v.read("dns.domains")
+	for _, val := range strings.Split(dnsDomains, ",") {
 		if val == "" {
 			break
 		}
@@ -119,6 +133,11 @@ func (v VMWare) FetchMetadata() (metadata datasource.Metadata, err error) {
 			address, _ := v.read("interface.%d.ip.%d.address", i, a)
 			if address == "" {
 				break
+			}
+			netmask, _ := v.read("interface.%d.ip.%d.netmask", i, a)
+			if netmask != "" {
+				ones, _ := net.IPMask(net.ParseIP(netmask).To4()).Size()
+				address = fmt.Sprintf("%s/%d", address, ones)
 			}
 			netDevice.Addresses = append(netDevice.Addresses, address)
 			found = true

--- a/config/cloudinit/datasource/vmware/vmware_amd64.go
+++ b/config/cloudinit/datasource/vmware/vmware_amd64.go
@@ -33,7 +33,10 @@ type ovfWrapper struct {
 }
 
 func (ovf ovfWrapper) readConfig(key string) (string, error) {
-	return ovf.env.Properties["guestinfo."+key], nil
+	if val := ovf.env.Properties["guestinfo."+key]; val != "" {
+		return val, nil
+	}
+	return readConfig(key)
 }
 
 func NewDatasource(fileName string) *VMWare {


### PR DESCRIPTION
Part of rancher/rancher#15817

Added `guestinfo` params:

- `interface.<n>.ip.<m>.netmask`
- `dns.servers`
- `dns.domains`

because vSphere doesn't provide IP address in CIDR format and have one field for DNS servers and one for DNS search paths.