### PR TITLE
Persistent ecs directory

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -123,6 +123,7 @@ rancher:
       - /run:/run
       - /usr/share/ros:/usr/share/ros
       - /var/lib/boot2docker:/var/lib/boot2docker
+      - /var/lib/ecs:/var/lib/ecs
       - /var/lib/rancher/cache:/var/lib/rancher/cache
       - /var/lib/rancher/conf:/var/lib/rancher/conf
       - /var/lib/rancher:/var/lib/rancher

--- a/pkg/dfs/scratch.go
+++ b/pkg/dfs/scratch.go
@@ -540,6 +540,12 @@ func createLayout(config *Config) error {
 		return err
 	}
 
+	ecsDirectory := "/var/lib/ecs"
+
+	if err := createDirs(ecsDirectory); err != nil {
+		return err
+	}
+
 	if err := createDaemonConfig(config); err != nil {
 		return err
 	}


### PR DESCRIPTION
According the ecs docs: [ecs doc](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#persistence)
ROS need persistent ecs directory '/var/lib/ecs'
#2394 