### PR TITLE
Add dhcp timeout params & remove useless types field

### DIFF
--- a/cmd/cloudinitsave/cloudinitsave.go
+++ b/cmd/cloudinitsave/cloudinitsave.go
@@ -284,12 +284,18 @@ func getDatasources(datasources []string) []datasource.Datasource {
 }
 
 func enableDoLinkLocal() {
+	cfg := rancherConfig.LoadConfig()
+	dhcpTimeout := cfg.Rancher.Defaults.Network.DHCPTimeout
+	if cfg.Rancher.Network.DHCPTimeout > 0 {
+		dhcpTimeout = cfg.Rancher.Network.DHCPTimeout
+	}
 	_, err := netconf.ApplyNetworkConfigs(&netconf.NetworkConfig{
 		Interfaces: map[string]netconf.InterfaceConfig{
 			"eth0": {
 				IPV4LL: true,
 			},
 		},
+		DHCPTimeout: dhcpTimeout,
 	}, false, false)
 	if err != nil {
 		log.Errorf("Failed to apply link local on eth0: %v", err)

--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -42,6 +42,9 @@ func ApplyNetworkConfig(cfg *config.CloudConfig) {
 	}
 
 	userSetHostname := cfg.Hostname != ""
+	if cfg.Rancher.Network.DHCPTimeout <= 0 {
+		cfg.Rancher.Network.DHCPTimeout = cfg.Rancher.Defaults.Network.DHCPTimeout
+	}
 	dhcpSetDNS, err := netconf.ApplyNetworkConfigs(&cfg.Rancher.Network, userSetHostname, userSetDNS)
 	if err != nil {
 		log.Errorf("Failed to apply network configs(by netconf): %v", err)

--- a/config/schema.go
+++ b/config/schema.go
@@ -81,6 +81,7 @@ var schema = `{
 
 			"properties": {
 				"pre_cmds": {"$ref": "#/definitions/list_of_strings"},
+				"dhcp_timeout": {"type": "integer"},
 				"dns": {"type": "object"},
 				"interfaces": {"type": "object"},
 				"post_cmds": {"$ref": "#/definitions/list_of_strings"},

--- a/config/schema.go
+++ b/config/schema.go
@@ -42,7 +42,6 @@ var schema = `{
 				"services_include": {"type": "object"},
 				"modules": {"$ref": "#/definitions/list_of_strings"},
 				"network": {"$ref": "#/definitions/network_config"},
-				"default_network": {"type": "object"},
 				"repositories": {"type": "object"},
 				"ssh": {"$ref": "#/definitions/ssh_config"},
 				"state": {"$ref": "#/definitions/state_config"},

--- a/config/types.go
+++ b/config/types.go
@@ -126,7 +126,6 @@ type RancherConfig struct {
 	ServicesInclude     map[string]bool                           `yaml:"services_include,omitempty"`
 	Modules             []string                                  `yaml:"modules,omitempty"`
 	Network             netconf.NetworkConfig                     `yaml:"network,omitempty"`
-	DefaultNetwork      netconf.NetworkConfig                     `yaml:"default_network,omitempty"`
 	Repositories        Repositories                              `yaml:"repositories,omitempty"`
 	SSH                 SSHConfig                                 `yaml:"ssh,omitempty"`
 	State               StateConfig                               `yaml:"state,omitempty"`

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -14,6 +14,7 @@ rancher:
       engine: docker-18.03.1-ce
     {{end -}}
     network:
+      dhcp_timeout: 10
       dns:
         nameservers: [8.8.8.8, 8.8.4.4]
     system_docker_logs: /var/log/system-docker.log

--- a/pkg/init/cloudinit/cloudinit.go
+++ b/pkg/init/cloudinit/cloudinit.go
@@ -13,6 +13,13 @@ func CloudInit(cfg *config.CloudConfig) (*config.CloudConfig, error) {
 	stateConfig := config.LoadConfigWithPrefix(config.StateDir)
 	cfg.Rancher.CloudInit.Datasources = stateConfig.Rancher.CloudInit.Datasources
 
+	if stateConfig.Rancher.Network.DHCPTimeout > 0 {
+		cfg.Rancher.Network.DHCPTimeout = stateConfig.Rancher.Network.DHCPTimeout
+		if err := config.Set("rancher.network.dhcp_timeout", stateConfig.Rancher.Network.DHCPTimeout); err != nil {
+			log.Error(err)
+		}
+	}
+
 	if len(stateConfig.Rancher.Network.Interfaces) > 0 {
 		cfg.Rancher.Network = stateConfig.Rancher.Network
 		if err := config.Set("rancher.network", stateConfig.Rancher.Network); err != nil {

--- a/pkg/netconf/netconf_linux.go
+++ b/pkg/netconf/netconf_linux.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -288,6 +289,10 @@ func runDhcp(netCfg *NetworkConfig, iface string, argstr string, setHostname, se
 
 	if !setDNS {
 		args = append(args, "--nohook", "resolv.conf")
+	}
+
+	if netCfg.DHCPTimeout > 0 {
+		args = append(args, "--timeout", strconv.Itoa(netCfg.DHCPTimeout))
 	}
 
 	// Wait for lease

--- a/pkg/netconf/types.go
+++ b/pkg/netconf/types.go
@@ -1,13 +1,14 @@
 package netconf
 
 type NetworkConfig struct {
-	PreCmds    []string                   `yaml:"pre_cmds,omitempty"`
-	DNS        DNSConfig                  `yaml:"dns,omitempty"`
-	Interfaces map[string]InterfaceConfig `yaml:"interfaces,omitempty"`
-	PostCmds   []string                   `yaml:"post_cmds,omitempty"`
-	HTTPProxy  string                     `yaml:"http_proxy,omitempty"`
-	HTTPSProxy string                     `yaml:"https_proxy,omitempty"`
-	NoProxy    string                     `yaml:"no_proxy,omitempty"`
+	PreCmds     []string                   `yaml:"pre_cmds,omitempty"`
+	DHCPTimeout int                        `yaml:"dhcp_timeout,omitempty"`
+	DNS         DNSConfig                  `yaml:"dns,omitempty"`
+	Interfaces  map[string]InterfaceConfig `yaml:"interfaces,omitempty"`
+	PostCmds    []string                   `yaml:"post_cmds,omitempty"`
+	HTTPProxy   string                     `yaml:"http_proxy,omitempty"`
+	HTTPSProxy  string                     `yaml:"https_proxy,omitempty"`
+	NoProxy     string                     `yaml:"no_proxy,omitempty"`
 }
 
 type InterfaceConfig struct {


### PR DESCRIPTION
Related: #2469 

### What's modified:
- Add  default value `rancher.default.network.dhcp_timeout 10` for dhcp
- Remove useless types field `rancher.default_network`

User can use this command `ros config rancher.network.dhcp_timeout xxxx` to change default `dhcp_timeout` value or set setction in cloud-config file:
```
rancher:
  network:
      dhcp_timeout: 20
```