### PR TITLE
Temporary fix build failure

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -133,7 +133,10 @@ RUN curl -pfL ${SELINUX_POLICY_URL} > ${DOWNLOADS}/$(basename ${SELINUX_POLICY_U
 
 # Install Go
 RUN wget -O - https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GOARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get golang.org/x/lint/golint
+    go get github.com/rancher/trash
+
+RUN mkdir -p ${GOPATH}/src/golang.org/x && cd ${GOPATH}/src/golang.org/x/ && git clone https://github.com/golang/tools && \
+    cd tools && git checkout 6adeb8aab2ded9eb693b831d5fd090c10a6ebdfa -b temp && go get golang.org/x/lint/golint
 
 # Install Host Docker
 RUN curl -fL ${!BUILD_DOCKER_URL} > /usr/bin/docker && \


### PR DESCRIPTION
The gotools cannot support the current golang version.
I temporarily roll back to a suitable version so that it does not affect
other developments.

https://github.com/rancher/os/issues/2532