### PR TITLE
[WIP] Added LVM and LUKS

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -169,6 +169,8 @@ var schema = `{
 				"required": {"type": "boolean"},
 				"autoformat": {"$ref": "#/definitions/list_of_strings"},
 				"mdadm_scan": {"type": "boolean"},
+				"cryptsetup": {"type": "boolean"},
+				"lvm_scan": {"type": "boolean"},
 				"rngd": {"type": "boolean"},
 				"script": {"type": "string"},
 				"oem_fstype": {"type": "string"},

--- a/config/types.go
+++ b/config/types.go
@@ -201,6 +201,8 @@ type StateConfig struct {
 	Required   bool     `yaml:"required,omitempty"`
 	Autoformat []string `yaml:"autoformat,omitempty"`
 	MdadmScan  bool     `yaml:"mdadm_scan,omitempty"`
+	LvmScan    bool     `yaml:"lvm_scan,omitempty"`
+	Cryptsetup bool     `yaml:"cryptsetup,omitempty"`
 	Rngd       bool     `yaml:"rngd,omitempty"`
 	Script     string   `yaml:"script,omitempty"`
 	OemFsType  string   `yaml:"oem_fstype,omitempty"`

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -164,6 +164,8 @@
         "required": {"type": "boolean"},
         "autoformat": {"$ref": "#/definitions/list_of_strings"},
         "mdadm_scan": {"type": "boolean"},
+        "cryptsetup": {"type": "boolean"},
+        "lvm_scan": {"type": "boolean"},
         "script": {"type": "string"},
         "oem_fstype": {"type": "string"},
         "oem_dev": {"type": "string"}


### PR DESCRIPTION
## What does this PR do

Closes https://github.com/rancher/os/issues/2551

Relies on a kernel with the following change: https://github.com/rancher/os-base/pull/54

Allows adding of new boot params to scan, detect and mount LVM and LUKS devices. 

## How this was tested

Live boot rancher.iso and setup disk using fdisks to reflect the following:
![fdisk](https://user-images.githubusercontent.com/4208881/47793854-e7f73100-dd27-11e8-84bd-89e2edd5177a.png)

Create LVM and LUKS partitions:
```
mkfs.ext4 -L RANCHER_BOOT /dev/sda1

cryptsetup -y -v luksFormat --force-password /dev/sda2
cryptsetup luksOpen /dev/sda2 luks-sda2
pvcreate /dev/mapper/luks-sda2
vgcreate vg0 /dev/mapper/luks-sda2
lvscan
mkfs.ext4 -L RANCHER_STATE /dev/vg0/root

ros install -f -t noformat -a "rancher.state.lvm_scan rancher.state.cryptsetup" --no-reboot

reboot
```

The following GIF is from the reboot command to show the boot process, with one incorrect passphrase entry before successful decryption.

![rancher-luks-2](https://user-images.githubusercontent.com/4208881/47795869-ee87a780-dd2b-11e8-91be-4ac8f685d8fa.gif)

Final `blkid` output:

![blkid](https://user-images.githubusercontent.com/4208881/47795937-06f7c200-dd2c-11e8-863c-e145e2b0014e.png)

