### PR TITLE
[WIP] Change dhcpcd master node startup function

### DIFF
--- a/pkg/netconf/netconf_linux.go
+++ b/pkg/netconf/netconf_linux.go
@@ -180,7 +180,17 @@ func ApplyNetworkConfigs(netCfg *NetworkConfig, userSetHostname, userSetDNS bool
 
 	//apply network config
 	for _, link := range links {
-		applyOuter(link, netCfg, &wg, userSetHostname, userSetDNS)
+		if !strings.Contains(link.Attrs().Name, "wlan") {
+			applyOuter(link, netCfg, &wg, userSetHostname, userSetDNS)
+		}
+	}
+	wg.Wait()
+
+	// apply wifi network config
+	for _, link := range links {
+		if strings.Contains(link.Attrs().Name, "wlan") {
+			applyOuter(link, netCfg, &wg, userSetHostname, userSetDNS)
+		}
 	}
 	wg.Wait()
 
@@ -337,7 +347,7 @@ func runWifiDhcp(netCfg *NetworkConfig, link netlink.Link, network string, setHo
 		removeAddress(addr, link)
 	}
 
-	runDhcp(netCfg, iface, "", !setHostname, setDNS)
+	runDhcp(netCfg, iface, "", setHostname, setDNS)
 }
 
 func linkUp(link netlink.Link, netConf InterfaceConfig) error {

--- a/pkg/netconf/netconf_linux.go
+++ b/pkg/netconf/netconf_linux.go
@@ -24,11 +24,10 @@ const (
 )
 
 var (
-	defaultDhcpArgs  = []string{"dhcpcd", "-MA4"}
-	inactiveDhcpArgs = []string{"dhcpcd", "-MA4", "--inactive"}
-	exitDhcpArgs     = []string{"dhcpcd", "-x"}
-	exitWpaArgs      = []string{"wpa_cli", "terminate"}
-	dhcpReleaseCmd   = "dhcpcd --release"
+	defaultDhcpArgs = []string{"dhcpcd", "-MA4"}
+	exitDhcpArgs    = []string{"dhcpcd", "-x"}
+	exitWpaArgs     = []string{"wpa_cli", "terminate"}
+	dhcpReleaseCmd  = "dhcpcd --release"
 )
 
 func createInterfaces(netCfg *NetworkConfig) {
@@ -179,12 +178,7 @@ func ApplyNetworkConfigs(netCfg *NetworkConfig, userSetHostname, userSetDNS bool
 
 	wg := sync.WaitGroup{}
 
-	// Don't start any interfaces other than those specified on the command line.
-	// This allows dhcpcd to be started in Master mode.
-	// Then wait for subsequent dhcpcd commands to start each interface as required.
-	runInactiveDhcp()
-
-	// apply network config
+	//apply network config
 	for _, link := range links {
 		applyOuter(link, netCfg, &wg, userSetHostname, userSetDNS)
 	}
@@ -286,15 +280,6 @@ func getDhcpLeaseString(iface string) []byte {
 func hasDhcp(iface string) bool {
 	out := getDhcpLeaseString(iface)
 	return len(out) > 0
-}
-
-func runInactiveDhcp() {
-	cmd := exec.Command(inactiveDhcpArgs[0], inactiveDhcpArgs[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Errorf("Failed to run command [%v]: %v", cmd, err)
-	}
 }
 
 func runDhcp(netCfg *NetworkConfig, iface string, argstr string, setHostname, setDNS bool) {


### PR DESCRIPTION
This PR is used to solve the problem of setting both eth0 and wlan0 from DHCP networks.
### Check-points
- [ ] configure wifi networks in cloud-init whether ip, hostname and dns are correct. (both dhcp and static mode)
- [ ] configure wifi networks in cloud-config whether ip,hostname and dns are correct. (both dhcp and static mode)
- [ ] check the `dhcp.timeout` parameter whether take effect or not.
- [ ] check different `dhcp.args` whether take effect or not.