### PR TITLE
Use host network for preload-user-images service

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -289,6 +289,7 @@ rancher:
     preload-user-images:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: ros preload-images
+      net: host
       labels:
         io.rancher.os.detach: "false"
         io.rancher.os.scope: system


### PR DESCRIPTION
This can avoid this dmesg error "system-dockerd segfault at 8 ip" on booting.

But this is not a complete fix just mitigation.

https://github.com/rancher/os/issues/2484