### PR TITLE
Roll back dapper to 0.3.4 because the latest version breaks the build

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -157,7 +157,7 @@ RUN curl -fL ${!BUILD_DOCKER_URL} > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 
 # Install dapper
-RUN curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m | sed 's/arm.*/arm/'` > /usr/bin/dapper && \
+RUN curl -sL https://releases.rancher.com/dapper/v0.3.4/dapper-`uname -s`-`uname -m | sed 's/arm.*/arm/'` > /usr/bin/dapper && \
     chmod +x /usr/bin/dapper
 
 RUN cd ${DOWNLOADS} && \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGETS := $(shell ls scripts | grep -vE 'clean|run|help|release*|build-moby|run
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m|sed 's/v7l//'` > .dapper.tmp
+	@curl -sL https://releases.rancher.com/dapper/v0.3.4/dapper-`uname -s`-`uname -m|sed 's/v7l//'` > .dapper.tmp
 	@@chmod +x .dapper.tmp
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper


### PR DESCRIPTION
https://github.com/rancher/dapper/issues/66
https://github.com/rancher/dapper/issues/67