### PR TITLE
Add firmware to support wireless on RPi3

### DIFF
--- a/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
@@ -12,17 +12,11 @@ RUN mkdir -p /source/assets
 #RUN curl -fL https://releases.rancher.com/os/latest/rootfs_arm64.tar.gz > /source/assets/rootfs_arm64.tar.gz
 COPY rootfs_arm64.tar.gz /source/assets/rootfs_arm64.tar.gz
 
-ENV URL=https://github.com/DieterReuter/rpi64-kernel/releases/download
-ENV VER=v20180426-171616
+ENV KERNEL_URL=https://github.com/DieterReuter/rpi64-kernel/releases/download/v20180426-171616/4.9.80-hypriotos-v8.tar.gz
+ENV BOOTLOADER_URL=https://github.com/DieterReuter/rpi-bootloader/releases/download/v20180320-071222/rpi-bootloader.tar.gz
 
-RUN curl -fL ${URL}/${VER}/4.9.80-hypriotos-v8.tar.gz > /source/assets/kernel.tar.gz
-RUN curl -fL ${URL}/${VER}/bootfiles.tar.gz > /source/assets/bootfiles.tar.gz
-RUN curl -fL https://github.com/DieterReuter/rpi-bootloader/releases/download/v20180320-071222/rpi-bootloader.tar.gz > /source/assets/rpi-bootfiles.tar.gz
-
-#ENV RPI_URL=https://github.com/raspberrypi/firmware/raw/master/boot
-#RUN curl -fL ${RPI_URL}/bootcode.bin > /source/assets/bootcode.bin
-#RUN curl -fL ${RPI_URL}/fixup.dat > /source/assets/fixup.dat
-#RUN curl -fL ${RPI_URL}/start.elf > /source/assets/start.elf
+RUN curl -fL ${KERNEL_URL} > /source/assets/kernel.tar.gz
+RUN curl -fL ${BOOTLOADER_URL} > /source/assets/rpi-bootfiles.tar.gz
 
 WORKDIR /source
 CMD ["./scripts/build.sh"]

--- a/scripts/images/raspberry-pi-hypriot64/scripts/build.sh
+++ b/scripts/images/raspberry-pi-hypriot64/scripts/build.sh
@@ -54,10 +54,6 @@ echo "RancherOS: root partition" > build/root/root.txt
 mkdir -p build/basefs
 tar -C build/basefs -zxvf build/kernel.tar.gz
 tar -C build/basefs -zxvf build/rpi-bootfiles.tar.gz
-tar -C build/basefs -zxvf build/bootfiles.tar.gz
-# remove RPi1 kernel, we only support RPi2 and RPi3 in ARMv7 mode
-rm -fr build/basefs/boot/kernel.img
-rm -fr build/basefs/lib/modules/{4.4.27+,4.4.27-hypriotos+}
 
 # populate kernel, bootloader and RancherOS rootfs
 cp -R build/basefs/* build/root
@@ -65,6 +61,16 @@ tar -xf assets/rootfs_arm64.tar.gz -C build/root
 echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup-enable=memory swapaccount=1 elevator=deadline rootwait console=ttyAMA0,115200 console=tty0 rancher.password=rancher rancher.autologin=ttyAMA0 rw init=/init" > build/root/boot/cmdline.txt
 # enable serial console mode for rpi3
 echo "enable_uart=1" > build/root/boot/config.txt
+
+## wireless support
+mkdir -p build/root/lib/firmware/brcm
+pushd build/root/lib/firmware/brcm
+curl -sL -o brcmfmac43430-sdio.txt https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/master/brcm/brcmfmac43430-sdio.txt
+curl -sL -o brcmfmac43430-sdio.bin https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/master/brcm/brcmfmac43430-sdio.bin
+curl -sL -o brcmfmac43455-sdio.bin https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/master/brcm/brcmfmac43455-sdio.bin
+curl -sL -o brcmfmac43455-sdio.clm_blob https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/master/brcm/brcmfmac43455-sdio.clm_blob
+curl -sL -o brcmfmac43455-sdio.txt https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/master/brcm/brcmfmac43455-sdio.txt
+popd
 
 # show details
 tree -a -L 3 build/root


### PR DESCRIPTION
Support for RPi 3b
```
brcmfmac43430-sdio.txt
brcmfmac43430-sdio.bin
```

Support for RPi 3b+
```
brcmfmac43455-sdio.bin
brcmfmac43455-sdio.clm_blob
brcmfmac43455-sdio.txt
```

Here are steps about how to enable wireless on RPi:
```
modprobe brcmfmac
wpa_passphrase <ssid> <psk> > /etc/wpa_supplicant.conf 
wpa_supplicant -iwlan0 -B -c /etc/wpa_supplicant.conf 
sleep 2 
dhcpcd -MA4 wlan0
```
