### PR TITLE
Support service cache update

### DIFF
--- a/pkg/util/network/cache.go
+++ b/pkg/util/network/cache.go
@@ -43,3 +43,8 @@ func cacheAdd(location string, data []byte) {
 	cacheFile := cacheDirectory + locationHash(location)
 	os.Rename(tempFile.Name(), cacheFile)
 }
+
+func cacheRemove(location string) error {
+	cacheFile := cacheDirectory + locationHash(location)
+	return os.Remove(cacheFile)
+}

--- a/pkg/util/network/network.go
+++ b/pkg/util/network/network.go
@@ -193,3 +193,38 @@ func LoadMultiEngineResource(name string) ([]byte, error) {
 
 	return nil, err
 }
+
+func UpdateCaches(urls []string, key string) error {
+	for _, url := range urls {
+		indexURL := fmt.Sprintf("%s/index.yml", url)
+		content, err := UpdateCache(indexURL)
+		if err != nil {
+			return err
+		}
+
+		services := make(map[string][]string)
+		err = yaml.Unmarshal(content, &services)
+		if err != nil {
+			return err
+		}
+
+		list := services[key]
+		for _, name := range list {
+			serviceURL := serviceURL(url, name)
+			// no need to handle error
+			UpdateCache(serviceURL)
+		}
+	}
+	return nil
+}
+
+func UpdateCache(location string) ([]byte, error) {
+	if err := cacheRemove(location); err != nil {
+		return []byte{}, err
+	}
+	content, err := LoadResource(location, true)
+	if err != nil {
+		return []byte{}, err
+	}
+	return content, nil
+}


### PR DESCRIPTION
## Features(#2677)
Existing cache files in this directory`(/var/lib/rancher/cache/)` will be updated, other files will not be affected.
- [x] `ros service list --update`
- [x] `ros console list --update`
- [x] `ros engine list --update`
- [x] `ros os list --update`

## Test Points
- Whether the `ros service list --update` is effective.
- Whether the `ros console list --update` is effective.
- Whether the `ros engine list --update` is effective.
- Whether the `ros os list --update` is effective.
- Whether the `ros service up` can  work with the updated cache file.
- Whether the `ros console switch` can  work with the updated cache file.
- Whether the `ros engine switch` can  work with the updated cache file.
- Whether the `ros os upgrade` can  work with the updated cache file.
- After the reboot everything went as expected