### PR TITLE
Added wildcard matching on MAC addresses.

### DIFF
--- a/pkg/netconf/netconf_linux.go
+++ b/pkg/netconf/netconf_linux.go
@@ -111,6 +111,11 @@ func findMatch(link netlink.Link, netCfg *NetworkConfig) (InterfaceConfig, bool)
 		}
 
 		if strings.HasPrefix(netConf.Match, "mac") {
+			if strings.Contains(netConf.Match, "*") {
+				// If selector contains wildcard * and MAC address matches wildcard then return
+				return netConf, glob.Glob(netConf.Match[4:], link.Attrs().HardwareAddr.String())
+			}
+
 			haAddr, err := net.ParseMAC(netConf.Match[4:])
 			if err != nil {
 				log.Errorf("Failed to parse mac %s: %v", netConf.Match[4:], err)

--- a/pkg/netconf/netconf_linux_test.go
+++ b/pkg/netconf/netconf_linux_test.go
@@ -1,0 +1,70 @@
+package netconf
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+type mockLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (l mockLink) Attrs() *netlink.LinkAttrs {
+	return &l.attrs
+}
+
+func (l mockLink) Type() string {
+	return "fake"
+}
+
+func TestFindMatch(t *testing.T) {
+	testCases := []struct {
+		match    string
+		mac      string
+		expected bool
+	}{
+		{
+			"mac:aa:bb:cc:dd:ee:ff",
+			"aa:bb:cc:dd:ee:ff",
+			true,
+		},
+		{
+			"mac:aa:bb:cc:*",
+			"aa:bb:cc:12:34:56",
+			true,
+		},
+		{
+			"mac:aa:bb:cc:*",
+			"11:bb:cc:dd:ee:ff",
+			false,
+		},
+		{
+			"mac:aa:bb:cc:dd:ee:ff",
+			"aa:bb:cc:dd:ee:11",
+			false,
+		},
+	}
+
+	for i, tt := range testCases {
+		netCfg := NetworkConfig{
+			Interfaces: map[string]InterfaceConfig{
+				"eth0": InterfaceConfig{
+					Match: tt.match,
+				},
+			},
+		}
+
+		linkAttrs := netlink.NewLinkAttrs()
+		linkAttrs.Name = "eth0"
+		linkAttrs.HardwareAddr, _ = net.ParseMAC(tt.mac)
+		link := mockLink{attrs: linkAttrs}
+
+		_, match := findMatch(link, &netCfg)
+
+		if match != tt.expected {
+			t.Errorf("Test case %d failed: mac: '%s' match '%s' expected: '%v' got: '%v'", i, tt.mac, tt.match, tt.expected, match)
+		}
+	}
+}


### PR DESCRIPTION
It would be a nice feature to be able to wildcard match on mac adresses for interfaces. This is eg. useful for bonding where you would like all nics of a certain make or model to be added to the bond.

Using this feature you could do the following:
```
#cloud-config
rancher:
  network:
    interfaces:
      bond0:
        dhcp: true
        bond_opts:
          mode: 802.3ad
          lacp_rate: fast
          miimon: 100
        post_up:
          - ip route add 0.0.0.0/0 via 1.2.3.4
      # Add all Mellanox adapters to bond
      "mac=98:03:9b*":
        bond: bond0
```
