### PR TITLE
Add config validation when reboot & shutdown

### DIFF
--- a/cmd/power/power.go
+++ b/cmd/power/power.go
@@ -131,8 +131,23 @@ func reboot(name string, force bool, code uint) {
 		log.Fatalf("%s: Need to be root", os.Args[0])
 	}
 
-	// Add shutdown timeout
 	cfg := config.LoadConfig()
+
+	// Validate config
+	if !force {
+		_, validationErrors, err := config.LoadConfigWithError()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if validationErrors != nil && !validationErrors.Valid() {
+			for _, validationError := range validationErrors.Errors() {
+				log.Error(validationError)
+			}
+			return
+		}
+	}
+
+	// Add shutdown timeout
 	timeoutValue := cfg.Rancher.ShutdownTimeout
 	if timeoutValue == 0 {
 		timeoutValue = 60


### PR DESCRIPTION
#2693 
### error cloud-config.yml
```
rancher:
  debug: abcde
```

### test result
```
[root@rancheros docker]# reboot
[            ] reboot:error: Failed to parse config file /var/lib/rancher/conf/cloud-config.yml: Invalid boolean: 'abcde' at line 1, column 9
[            ] reboot:fatal: Invalid boolean: 'abcde' at line 1, column 9

[root@rancheros docker]# shutdown
[            ] shutdown:error: Failed to parse config file /var/lib/rancher/conf/cloud-config.yml: Invalid boolean: 'abcde' at line 1, column 9
[            ] shutdown:fatal Invalid boolean: 'abcde' at line 1, column 9
```