### PR TITLE
Wildcard mac matching fix

### DIFF
--- a/pkg/netconf/netconf_linux.go
+++ b/pkg/netconf/netconf_linux.go
@@ -113,7 +113,11 @@ func findMatch(link netlink.Link, netCfg *NetworkConfig) (InterfaceConfig, bool)
 		if strings.HasPrefix(netConf.Match, "mac") {
 			if strings.Contains(netConf.Match, "*") {
 				// If selector contains wildcard * and MAC address matches wildcard then return
-				return netConf, glob.Glob(netConf.Match[4:], link.Attrs().HardwareAddr.String())
+				// Don't match mac address of a bond or VLAN interface because it is the same address as the slave or parent.
+				if glob.Glob(netConf.Match[4:], link.Attrs().HardwareAddr.String()) && link.Attrs().Name != netConf.Bond && link.Type() != "vlan" {
+					return netConf, true
+				}
+				continue
 			}
 
 			haAddr, err := net.ParseMAC(netConf.Match[4:])

--- a/pkg/netconf/netconf_linux_test.go
+++ b/pkg/netconf/netconf_linux_test.go
@@ -9,6 +9,7 @@ import (
 
 type mockLink struct {
 	attrs netlink.LinkAttrs
+	t     string
 }
 
 func (l mockLink) Attrs() *netlink.LinkAttrs {
@@ -16,33 +17,57 @@ func (l mockLink) Attrs() *netlink.LinkAttrs {
 }
 
 func (l mockLink) Type() string {
-	return "fake"
+	return l.t
 }
 
 func TestFindMatch(t *testing.T) {
 	testCases := []struct {
 		match    string
 		mac      string
+		t        string
+		name     string
+		bond     string
 		expected bool
 	}{
 		{
 			"mac:aa:bb:cc:dd:ee:ff",
 			"aa:bb:cc:dd:ee:ff",
+			"fake",
+			"eth0",
+			"bond0",
 			true,
 		},
 		{
 			"mac:aa:bb:cc:*",
 			"aa:bb:cc:12:34:56",
+			"fake",
+			"eth0",
+			"bond0",
 			true,
 		},
 		{
 			"mac:aa:bb:cc:*",
 			"11:bb:cc:dd:ee:ff",
+			"fake",
+			"eth0",
+			"bond0",
 			false,
 		},
 		{
 			"mac:aa:bb:cc:dd:ee:ff",
 			"aa:bb:cc:dd:ee:11",
+			"fake",
+			"eth0",
+			"bond0",
+			false,
+		},
+		// This is a bond eg. bond0
+		{
+			"mac:aa:bb:*",
+			"aa:bb:cc:dd:ee:11",
+			"bond",
+			"bond0",
+			"bond0",
 			false,
 		},
 	}
@@ -50,14 +75,15 @@ func TestFindMatch(t *testing.T) {
 	for i, tt := range testCases {
 		netCfg := NetworkConfig{
 			Interfaces: map[string]InterfaceConfig{
-				"eth0": InterfaceConfig{
+				tt.name: InterfaceConfig{
 					Match: tt.match,
+					Bond:  tt.bond,
 				},
 			},
 		}
 
 		linkAttrs := netlink.NewLinkAttrs()
-		linkAttrs.Name = "eth0"
+		linkAttrs.Name = tt.name
 		linkAttrs.HardwareAddr, _ = net.ParseMAC(tt.mac)
 		link := mockLink{attrs: linkAttrs}
 
@@ -67,4 +93,5 @@ func TestFindMatch(t *testing.T) {
 			t.Errorf("Test case %d failed: mac: '%s' match '%s' expected: '%v' got: '%v'", i, tt.mac, tt.match, tt.expected, match)
 		}
 	}
+
 }


### PR DESCRIPTION
#2706 has an issue where you have to manually run dhcpcd after the os is booted. That is because that PR didn't whether the interface was a bond or vlan interface like it should (that is the functionality when matching on strict MAC address).

I've corrected this and added testing for that specific case.