### PR TITLE
[WIP] Bump up kernel to 4.19.37

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=RancherOS
 
 ARG SELINUX_POLICY_URL=https://github.com/rancher/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.85-rancher
+ARG KERNEL_VERSION=4.19.37-rancher
 ARG KERNEL_URL_amd64=https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 


### PR DESCRIPTION
https://github.com/rancher/os/issues/2728


We also need to update hyperv and azure images.
The os-base and os-initrd-base should be built by 4.19.x kernel header.