### PR TITLE
Wait for net routes before loading resource from network

### DIFF
--- a/pkg/util/network/network.go
+++ b/pkg/util/network/network.go
@@ -7,12 +7,17 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rancher/os/config"
 	"github.com/rancher/os/pkg/log"
 
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	composeConfig "github.com/docker/libcompose/config"
+)
+
+const (
+	defaultTimeout = 10 * time.Second
 )
 
 var (
@@ -110,7 +115,10 @@ func LoadFromNetwork(location string) ([]byte, error) {
 
 	var resp *http.Response
 	log.Debugf("LoadFromNetwork(%s)", location)
-	resp, err = http.Get(location)
+	netClient := &http.Client{
+		Timeout: defaultTimeout,
+	}
+	resp, err = netClient.Get(location)
 	log.Debugf("LoadFromNetwork(%s) returned %v, %v", location, resp, err)
 	if err == nil {
 		defer resp.Body.Close()

--- a/pkg/util/network/network.go
+++ b/pkg/util/network/network.go
@@ -101,9 +101,12 @@ func LoadFromNetworkWithCache(location string) ([]byte, error) {
 }
 
 func LoadFromNetwork(location string) ([]byte, error) {
-	SetProxyEnvironmentVariables()
-
 	var err error
+
+	if err = AllDefaultGWOK(DefaultRoutesCheckTimeout); err != nil {
+		return nil, err
+	}
+	SetProxyEnvironmentVariables()
 
 	var resp *http.Response
 	log.Debugf("LoadFromNetwork(%s)", location)

--- a/pkg/util/network/route.go
+++ b/pkg/util/network/route.go
@@ -1,0 +1,109 @@
+package network
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rancher/os/pkg/log"
+	"github.com/rancher/os/pkg/util"
+)
+
+const (
+	DefaultRoutesCheckTimeout = 20000 // 20 second
+
+	ipv4RouteFile = "/proc/net/route"
+	ipv6RouteFile = "/proc/net/ipv6_route"
+
+	ipv4DefaultGWFlags = "0003"
+	ipv6DefaultGWFlags = "00450003"
+)
+
+func checkIPv4GW() bool {
+	if _, err := os.Stat(ipv4RouteFile); os.IsNotExist(err) {
+		return false
+	}
+	file, err := os.Open(ipv4RouteFile)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	scanner := bufio.NewReader(file)
+	for {
+		line, err := scanner.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		//ignore the headers in the route info
+		if strings.HasPrefix(line, "Iface") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Interested in fields:
+		//  3 - flags
+		if fields[3] == ipv4DefaultGWFlags {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkIPv6GW() bool {
+	if _, err := os.Stat(ipv6RouteFile); os.IsNotExist(err) {
+		return false
+	}
+	file, err := os.Open(ipv6RouteFile)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	scanner := bufio.NewReader(file)
+	for {
+		line, err := scanner.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		fields := strings.Fields(line)
+		// Interested in fields:
+		//  3 - flags
+		if fields[3] == ipv6DefaultGWFlags {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkAllDefaultGW() bool {
+	return checkIPv4GW() || checkIPv6GW()
+}
+
+func AllDefaultGWOK(timeout int) error {
+	backoff := util.Backoff{
+		MaxMillis: timeout,
+	}
+	defer backoff.Close()
+
+	var err error
+	for ok := range backoff.Start() {
+		if !ok {
+			err = fmt.Errorf("Timeout waiting for the default gateway ready")
+			break
+		}
+		if checkAllDefaultGW() {
+			break
+		}
+		log.Info("Waiting for the default gateway ready")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	log.Info("The default gateway is ready")
+
+	return nil
+}


### PR DESCRIPTION
These issues can be mitigated:
- https://github.com/rancher/os/issues/2804
- https://github.com/rancher/os/issues/2812
- https://github.com/rancher/os/issues/2653

Before loading resource from the network, we need to check if the default gateway is ready.

I tested this case on VMware by manually attaching or detaching the NIC.