### PR TITLE
Fix bug: Logrotate will start failed when the config file is not with 644 file permission

### DIFF
--- a/images/02-logrotate/Dockerfile
+++ b/images/02-logrotate/Dockerfile
@@ -1,3 +1,4 @@
 FROM rancher/os-base
 COPY . /
+RUN chmod 644 /etc/logrotate.conf
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]


### PR DESCRIPTION
Related Issue:
https://github.com/rancher/os/issues/2811