### PR TITLE
Remove the tee command which will cause the dapper container's tty to be false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ release: .dapper release-build
 
 release-build:
 	mkdir -p dist
-	./.dapper release 2>&1 | tee dist/release.log
+	./.dapper release
 
 rpi64: .dapper
 	./scripts/release-rpi64
@@ -49,34 +49,34 @@ rpi64: .dapper
 vmware: .dapper
 	mkdir -p dist
 	APPEND_SYSTEM_IMAGES="rancher/os-openvmtools:10.3.10-1" \
-	./.dapper release-vmware 2>&1 | tee dist/release.log
+	./.dapper release-vmware
 
 hyperv: .dapper
 	mkdir -p dist
 	APPEND_SYSTEM_IMAGES="rancher/os-hypervvmtools:v4.14.128-rancher-1" \
-	./.dapper release-hyperv 2>&1 | tee dist/release.log
+	./.dapper release-hyperv
 
 azurebase: .dapper
 	mkdir -p dist
 	AZURE_SERVICE="true" \
 	APPEND_SYSTEM_IMAGES="rancher/os-hypervvmtools:v4.14.128-rancher-1 rancher/os-waagent:v2.2.34-1" \
-	./.dapper release-azurebase 2>&1 | tee dist/release.log
+	./.dapper release-azurebase
 
 4glte: .dapper
 	mkdir -p dist
 	APPEND_SYSTEM_IMAGES="rancher/os-modemmanager:v1.6.4-1" \
-	./.dapper release-4glte 2>&1 | tee dist/release.log
+	./.dapper release-4glte
 
 proxmoxve: .dapper
 	mkdir -p dist
 	PROXMOXVE_SERVICE="true" \
 	APPEND_SYSTEM_IMAGES="rancher/os-qemuguestagent:v2.8.1-2" \
-	./.dapper release-proxmoxve 2>&1 | tee dist/release.log
+	./.dapper release-proxmoxve
 
 pingan: .dapper
 	mkdir -p dist
 	APPEND_SYSTEM_IMAGES="cnrancher/os-pingan-amc:v0.0.6-1" \
-	./.dapper release-pingan 2>&1 | tee dist/release.log
+	./.dapper release-pingan
 
 help:
 	@./scripts/help


### PR DESCRIPTION
https://github.com/rancher/os/issues/2862

From my test:
This part `2>&1 | tee dist/release.log` will disable the tty of dapper containers, which will cause the VMware build to fail. As `make vmware` will run `kvm -curse`, which needs to redirect the output t on terminal.