### PR TITLE
Fix Exoscale Cloudinit datasource race condition

### DIFF
--- a/config/cloudinit/datasource/metadata/exoscale/metadata.go
+++ b/config/cloudinit/datasource/metadata/exoscale/metadata.go
@@ -39,6 +39,16 @@ func NewDatasource(root string) *MetadataService {
 	}
 }
 
+func (ms MetadataService) IsAvailable() bool {
+	checkURL := ms.Root + ms.IsAvailableCheckPath
+	var err error
+	_, err = ms.Client.GetRetry(checkURL)
+	if err != nil {
+		log.Errorf("%s: %s (lastError: %v)", "IsAvailable", checkURL, err)
+	}
+	return (err == nil)
+}
+
 func (ms MetadataService) AvailabilityChanges() bool {
 	// TODO: if it can't find the network, maybe we can start it?
 	return false


### PR DESCRIPTION
This PR fix a race condition in the Cloudinit Exoscale provider.
The problem was at datasource level, when it tries to get the datasource, sometime the instance network interface is not up or starting. 
So the request was failing.