### PR TITLE
Prefer to use go dns

### DIFF
--- a/pkg/util/network/network.go
+++ b/pkg/util/network/network.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
 
@@ -108,6 +109,7 @@ func LoadFromNetwork(location string) ([]byte, error) {
 	}
 	SetProxyEnvironmentVariables()
 
+	net.DefaultResolver.PreferGo = true
 	cfg := config.LoadConfig()
 	client := httpRetry.NewHTTPClient()
 	client.MaxRetries = cfg.Rancher.HTTPLoadRetries


### PR DESCRIPTION
We should use netgo as the default dns resolver, so that user can use `*.local` domain.

https://github.com/rancher/os/issues/2941