### PR TITLE
Fix memory leak in selinux_linux.go

### DIFF
--- a/pkg/selinux/selinux_linux.go
+++ b/pkg/selinux/selinux_linux.go
@@ -2,7 +2,12 @@ package selinux
 
 // #cgo pkg-config: libselinux libsepol
 // #include <selinux/selinux.h>
+// #include <stdlib.h>
 import "C"
+
+import (
+	"unsafe"
+)
 
 func InitializeSelinux() (int, error) {
 	enforce := C.int(0)
@@ -11,6 +16,12 @@ func InitializeSelinux() (int, error) {
 }
 
 func SetFileContext(path string, context string) (int, error) {
-	ret, err := C.setfilecon(C.CString(path), C.CString(context))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cContext := C.CString(context)
+	defer C.free(unsafe.Pointer(cContext))
+
+	ret, err := C.setfilecon(cPath, cContext)
 	return int(ret), err
 }


### PR DESCRIPTION
I have not tested this, but was searching for memory leaks using [this CS query](https://cs.github.com/rancher/os?q=%22%2C%20C.CString%22) and came across this instance in rancher/os. Since it's so widely used I figured it's worth at least pointing out.